### PR TITLE
Update to go1.15.1, use distroless image, and lint codebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: circleci/golang:1.12
+    - image: circleci/golang:1.15
     environment:
       TEST_RESULTS: /tmp/test-results
 
@@ -36,7 +36,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,9 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
     - goconst
     - gocritic
     - gocyclo
@@ -26,7 +29,9 @@ linters:
     - gofmt
     - goimports
     - golint
+    - gomnd
     - goprintffuncname
+    - gosec
     - gosimple
     - govet
     - ineffassign
@@ -36,6 +41,7 @@ linters:
     - nakedret
     - prealloc
     - rowserrcheck
+    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -45,15 +51,12 @@ linters:
     - unused
     - varcheck
     - whitespace
-    # - funlen
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - gocognit
-    # - gomnd
-    # - gosec
-    # - lll
-    # - scopelint
-    # - wsl
+
+    # Nits: These are things one might mention, but not block on during review.
+    #       We can consider disabling these checks, if we determine them to be
+    #       a little too nitty and obtrusive.
+    - lll
+    - wsl
 linters-settings:
   godox:
     keywords:
@@ -106,6 +109,7 @@ linters-settings:
       - emptyFallthrough
       - emptyStringTest
       - hexLiteral
+      - ifElseChain
       - methodExprCall
       - regexpMust
       - singleCaseSwitch
@@ -121,7 +125,6 @@ linters-settings:
       - valSwap
       - wrapperFunc
       - yodaStyleExpr
-      # - ifElseChain
 
       # Opinionated
       - builtinShadow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,135 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+issues:
+  exclude-rules:
+    # counterfeiter fakes are usually named 'fake_<something>.go'
+    - path: fake_.*\.go
+      linters:
+        - gocritic
+        - golint
+        - dupl
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - goimports
+    - golint
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - prealloc
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    # - funlen
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - gomnd
+    # - gosec
+    # - lll
+    # - scopelint
+    # - wsl
+linters-settings:
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+      # - ifElseChain
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.12-alpine as builder
 
 RUN apk --update add git upx
 
-WORKDIR /go/src/github.com/pluies/zeitgeist
+WORKDIR /go/src/sigs.k8s.io/zeitgeist
 ENV GO111MODULE=on
 ADD go.mod .
 ADD go.sum .
@@ -32,7 +32,7 @@ FROM scratch
 # Copy trusted CAs for TLS
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 # And our executable!
-COPY --from=builder /go/src/github.com/pluies/zeitgeist/zeitgeist /
+COPY --from=builder /go/src/sigs.k8s.io/zeitgeist/zeitgeist /
 # Run as non-root
 USER 1001
 CMD ["/zeitgeist"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12-alpine as builder
+FROM golang:1.15-alpine as builder
 
 RUN apk --update add git upx
 

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12-alpine as builder
+FROM golang:1.15-alpine as builder
 COPY zeitgeist /
 CMD ["/zeitgeist"]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ([/ˈzaɪtɡaɪst/](https://en.wikipedia.org/wiki/Help:IPA/English)) is a language-agnostic dependency checker that keeps track of external dependencies across your project and ensure they're up-to-date.
 
 [![CircleCI](https://circleci.com/gh/Pluies/zeitgeist.svg?style=shield)](https://circleci.com/gh/Pluies/zeitgeist)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Pluies/zeitgeist)](https://goreportcard.com/report/github.com/Pluies/zeitgeist)
-[![GoDoc](https://godoc.org/github.com/Pluies/zeitgeist?status.svg)](https://godoc.org/github.com/Pluies/zeitgeist)
+[![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/zeitgeist)](https://goreportcard.com/report/sigs.k8s.io/zeitgeist)
+[![GoDoc](https://godoc.org/sigs.k8s.io/zeitgeist?status.svg)](https://godoc.org/sigs.k8s.io/zeitgeist)
 
 - [Rationale](#rationale)
 - [What is Zeitgeist](#what-is-zeitgeist)
@@ -90,7 +90,7 @@ Use `zeitgeist validate` to also check with defined `upstreams` whether a new ve
 
 ![zeigeist validate](/docs/validate.png)
 
-See the [full documentation](https://godoc.org/github.com/Pluies/zeitgeist/dependencies#Dependency) to see configuration options.
+See the [full documentation](https://godoc.org/sigs.k8s.io/zeitgeist/dependencies#Dependency) to see configuration options.
 
 ## When is Zeitgeist _not_ suggested
 

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -86,7 +86,7 @@ func (decoded *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	case Semver, Alpha, Random:
 		// All good!
 	default:
-		return fmt.Errorf("Unknown version scheme: %s", d.Scheme)
+		return fmt.Errorf("unknown version scheme: %s", d.Scheme)
 	}
 	log.Debugf("Deserialised Dependency %v: %v", d.Name, d)
 	return nil
@@ -215,7 +215,7 @@ func RemoteCheck(dependencyFilePath string) ([]string, error) {
 			}
 			latestVersion.Version, err = helm.LatestVersion()
 		default:
-			return nil, fmt.Errorf("Unknown upstream flavour '%v' for dependency %v", flavour, dep.Name)
+			return nil, fmt.Errorf("unknown upstream flavour '%v' for dependency %v", flavour, dep.Name)
 		}
 		if err != nil {
 			return nil, err

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -27,11 +27,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pluies/zeitgeist/upstreams"
-
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+
+	"sigs.k8s.io/zeitgeist/upstreams"
 )
 
 // Dependencies is used to deserialise the configuration file

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -157,7 +157,7 @@ func LocalCheck(dependencyFilePath string) error {
 				if matcher.MatchString(line) {
 					if strings.Contains(line, dep.Version) {
 						log.Debugf(
-							"Line %v matches expected regexp '%v' and version '%v':\n%v",
+							"Line %v matches expected regexp '%v' and version '%v': %v",
 							lineNumber,
 							match,
 							dep.Version,
@@ -168,7 +168,13 @@ func LocalCheck(dependencyFilePath string) error {
 
 						break
 					} else {
-						log.Warnf("Line %v matches expected regexp '%v', but not version '%v':\n%v", lineNumber, match, dep.Version, line)
+						log.Warnf(
+							"Line %v matches expected regexp '%v', but not version '%v': %v",
+							lineNumber,
+							match,
+							dep.Version,
+							line,
+						)
 					}
 				}
 			}
@@ -181,8 +187,14 @@ func LocalCheck(dependencyFilePath string) error {
 		}
 
 		if len(nonMatchingPaths) > 0 {
-			log.Errorf("%v indicates that %v should be at version %v, but the following files didn't match:\n"+
-				"%v\n", dependencyFilePath, dep.Name, dep.Version, strings.Join(nonMatchingPaths, "\n"))
+			log.Errorf(
+				"%v indicates that %v should be at version %v, but the following files didn't match: %v",
+				dependencyFilePath,
+				dep.Name,
+				dep.Version,
+				strings.Join(nonMatchingPaths, ", "),
+			)
+
 			return errors.New("Dependencies are not in sync")
 		}
 	}

--- a/dependencies/dependencies_test.go
+++ b/dependencies/dependencies_test.go
@@ -56,6 +56,7 @@ func TestBrokenFile(t *testing.T) {
 	if err == nil {
 		t.Errorf("Did not return an error on trying to open a file that doesn't exist")
 	}
+
 	err = LocalCheck("../testdata/Dockerfile")
 	if err == nil {
 		t.Errorf("Did not return an error on trying to open a non-yaml file")
@@ -107,6 +108,7 @@ func TestDeserialising(t *testing.T) {
 
 	for _, valid := range validYamls {
 		var d Dependency
+
 		err := yaml.Unmarshal([]byte(valid), &d)
 		if err != nil {
 			t.Errorf("Failed to deserialise valid yaml:\n%s", valid)

--- a/dependencies/versions.go
+++ b/dependencies/versions.go
@@ -69,15 +69,15 @@ func (a Version) MoreSensitivelyRecentThan(b Version, sensitivity VersionSensiti
 		sensitivity = Patch
 	}
 	if a.Scheme != b.Scheme {
-		return false, fmt.Errorf("Trying to compare incompatible Version schemes: %s and %s", a.Scheme, b.Scheme)
+		return false, fmt.Errorf("trying to compare incompatible 'Version' schemes: %s and %s", a.Scheme, b.Scheme)
 	}
 	switch a.Scheme {
 	case Semver:
-		aSemver, err := semver.Parse(string(a.Version))
+		aSemver, err := semver.Parse(a.Version)
 		if err != nil {
 			return false, err
 		}
-		bSemver, err := semver.Parse(string(b.Version))
+		bSemver, err := semver.Parse(b.Version)
 		if err != nil {
 			return false, err
 		}
@@ -89,12 +89,12 @@ func (a Version) MoreSensitivelyRecentThan(b Version, sensitivity VersionSensiti
 		// When identifiers are random (e.g. hashes), the newer version will just be a different version
 		return a.Version != b.Version, nil
 	default:
-		return false, fmt.Errorf("Unknown version scheme: %s", a.Scheme)
+		return false, fmt.Errorf("unknown version scheme: %s", a.Scheme)
 	}
 }
 
 // semverCompare compares two semver versions depending on a sensitivity level
-func semverCompare(a semver.Version, b semver.Version, sensitivity VersionSensitivity) (bool, error) {
+func semverCompare(a, b semver.Version, sensitivity VersionSensitivity) (bool, error) {
 	switch sensitivity {
 	case Major:
 		return a.Major > b.Major, nil
@@ -103,6 +103,6 @@ func semverCompare(a semver.Version, b semver.Version, sensitivity VersionSensit
 	case Patch:
 		return a.GT(b), nil
 	default:
-		return false, fmt.Errorf("Unknown version sensitivity: %s", sensitivity)
+		return false, fmt.Errorf("unknown version sensitivity: %s", sensitivity)
 	}
 }

--- a/dependencies/versions.go
+++ b/dependencies/versions.go
@@ -40,7 +40,8 @@ const (
 	Random VersionScheme = "random"
 )
 
-// VersionSensitivity informs us on how to compare whether a version is more recent than another, for example to only notify on new major versions
+// VersionSensitivity informs us on how to compare whether a version is more
+// recent than another, for example to only notify on new major versions
 // Only applicable to Semver versioning
 type VersionSensitivity string
 
@@ -60,7 +61,8 @@ func (a Version) MoreRecentThan(b Version) (bool, error) {
 	return a.MoreSensitivelyRecentThan(b, Patch)
 }
 
-// MoreSensitivelyRecentThan checks whether a given version is more recent than another one, accepting a VersionSensitivity argument
+// MoreSensitivelyRecentThan checks whether a given version is more recent than
+// another one, accepting a VersionSensitivity argument
 //
 // If the VersionScheme is "random", then it will return true if a != b.
 func (a Version) MoreSensitivelyRecentThan(b Version, sensitivity VersionSensitivity) (bool, error) {
@@ -68,19 +70,23 @@ func (a Version) MoreSensitivelyRecentThan(b Version, sensitivity VersionSensiti
 	if sensitivity == "" {
 		sensitivity = Patch
 	}
+
 	if a.Scheme != b.Scheme {
 		return false, fmt.Errorf("trying to compare incompatible 'Version' schemes: %s and %s", a.Scheme, b.Scheme)
 	}
+
 	switch a.Scheme {
 	case Semver:
 		aSemver, err := semver.Parse(a.Version)
 		if err != nil {
 			return false, err
 		}
+
 		bSemver, err := semver.Parse(b.Version)
 		if err != nil {
 			return false, err
 		}
+
 		return semverCompare(aSemver, bSemver, sensitivity)
 	case Alpha:
 		// Alphanumeric comparison (basic string compare)

--- a/dependencies/versions_test.go
+++ b/dependencies/versions_test.go
@@ -20,6 +20,10 @@ import (
 	"testing"
 )
 
+// TODO: These tests should be refactored to be table-driven
+//       Additionally, we can use https://github.com/stretchr/testify/require
+//       to check the various statuses.
+
 func TestSanity(t *testing.T) {
 	var err error
 
@@ -60,16 +64,19 @@ func TestSemverVersions(t *testing.T) {
 	a := Version{"1.0.0", Semver}
 	b := Version{"2.0.0", Semver}
 
+	// nolint: errcheck
 	shouldBeFalse, _ := a.MoreRecentThan(b)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", a, b)
 	}
 
+	// nolint: errcheck
 	shouldBeTrue, _ := b.MoreRecentThan(a)
 	if shouldBeTrue == false {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", b, a)
 	}
 
+	// nolint: errcheck
 	shouldBeFalse, _ = a.MoreRecentThan(a)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent than itself; it should not be", a)
@@ -80,16 +87,19 @@ func TestSemverSensitiveVersions(t *testing.T) {
 	a := Version{"1.0.0", Semver}
 	b := Version{"1.1.0", Semver}
 
+	// nolint: errcheck
 	shouldBeFalse, _ := b.MoreSensitivelyRecentThan(a, Major)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v should not be more recent that version %v with sensitivity %v", b, a, Major)
 	}
 
+	// nolint: errcheck
 	shouldBeTrue, _ := b.MoreSensitivelyRecentThan(a, Minor)
 	if shouldBeTrue != true {
 		t.Errorf("Version %v should be more recent that version %v with sensitivity %v", b, a, Minor)
 	}
 
+	// nolint: errcheck
 	shouldBeTrue, _ = b.MoreSensitivelyRecentThan(a, Patch)
 	if shouldBeTrue != true {
 		t.Errorf("Version %v should be more recent that version %v with sensitivity %v", b, a, Patch)
@@ -98,16 +108,19 @@ func TestSemverSensitiveVersions(t *testing.T) {
 	a = Version{"1.0.0", Semver}
 	b = Version{"1.0.1", Semver}
 
+	// nolint: errcheck
 	shouldBeFalse, _ = b.MoreSensitivelyRecentThan(a, Major)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v should not be more recent that version %v with sensitivity %v", b, a, Major)
 	}
 
+	// nolint: errcheck
 	shouldBeFalse, _ = b.MoreSensitivelyRecentThan(a, Minor)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v should not be more recent that version %v with sensitivity %v", b, a, Minor)
 	}
 
+	// nolint: errcheck
 	shouldBeTrue, _ = b.MoreSensitivelyRecentThan(a, Patch)
 	if shouldBeTrue != true {
 		t.Errorf("Version %v should be more recent that version %v with sensitivity %v", b, a, Patch)
@@ -121,6 +134,7 @@ func TestSemverSensitiveVersions(t *testing.T) {
 	a = Version{"6.21.0", Semver}
 	b = Version{"8.1.8", Semver}
 
+	// nolint: errcheck
 	shouldBeTrue, _ = b.MoreSensitivelyRecentThan(a, Minor)
 	if shouldBeTrue != true {
 		t.Errorf("Version %v should be more recent that version %v with sensitivity %v", b, a, Minor)
@@ -131,16 +145,19 @@ func TestAlphaVersions(t *testing.T) {
 	a := Version{"20180101-commitid", Alpha}
 	b := Version{"20180505-commitid", Alpha}
 
+	// nolint: errcheck
 	shouldBeFalse, _ := a.MoreRecentThan(b)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", a, b)
 	}
 
+	// nolint: errcheck
 	shouldBeTrue, _ := b.MoreRecentThan(a)
 	if shouldBeTrue == false {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", b, a)
 	}
 
+	// nolint: errcheck
 	shouldBeFalse, _ = a.MoreRecentThan(a)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent than itself; it should not be", a)
@@ -151,11 +168,13 @@ func TestRandomVersions(t *testing.T) {
 	a := Version{"ami-09bbefc07310f7914", Random}
 	b := Version{"ami-0199284372364b02a", Random}
 
+	// nolint: errcheck
 	shouldBeTrue, _ := b.MoreRecentThan(a)
 	if shouldBeTrue == false {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", b, a)
 	}
 
+	// nolint: errcheck
 	shouldBeFalse, _ := a.MoreRecentThan(a)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent than itself; it should not be", a)

--- a/dependencies/versions_test.go
+++ b/dependencies/versions_test.go
@@ -25,6 +25,7 @@ func TestSanity(t *testing.T) {
 
 	a := Version{"1.0.0", Semver}
 	b := Version{"2.0.0", Alpha}
+
 	_, err = a.MoreRecentThan(b)
 	if err == nil {
 		t.Errorf("Should error on copmparing different types")
@@ -32,6 +33,7 @@ func TestSanity(t *testing.T) {
 
 	a = Version{"1.0.0", "Foo"}
 	b = Version{"2.0.0", "Foo"}
+
 	_, err = a.MoreRecentThan(b)
 	if err == nil {
 		t.Errorf("Should error on copmparing unknown types")
@@ -39,6 +41,7 @@ func TestSanity(t *testing.T) {
 
 	a = Version{"ami-1234", Semver}
 	b = Version{"ami-4567", Semver}
+
 	_, err = a.MoreRecentThan(b)
 	if err == nil {
 		t.Errorf("Should error on broken Semver strings")
@@ -46,6 +49,7 @@ func TestSanity(t *testing.T) {
 
 	a = Version{"1.0.0", Semver}
 	b = Version{"bad-version", Semver}
+
 	_, err = a.MoreRecentThan(b)
 	if err == nil {
 		t.Errorf("Should error on broken Semver strings")
@@ -55,14 +59,17 @@ func TestSanity(t *testing.T) {
 func TestSemverVersions(t *testing.T) {
 	a := Version{"1.0.0", Semver}
 	b := Version{"2.0.0", Semver}
+
 	shouldBeFalse, _ := a.MoreRecentThan(b)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", a, b)
 	}
+
 	shouldBeTrue, _ := b.MoreRecentThan(a)
 	if shouldBeTrue == false {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", b, a)
 	}
+
 	shouldBeFalse, _ = a.MoreRecentThan(a)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent than itself; it should not be", a)
@@ -72,6 +79,7 @@ func TestSemverVersions(t *testing.T) {
 func TestSemverSensitiveVersions(t *testing.T) {
 	a := Version{"1.0.0", Semver}
 	b := Version{"1.1.0", Semver}
+
 	shouldBeFalse, _ := b.MoreSensitivelyRecentThan(a, Major)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v should not be more recent that version %v with sensitivity %v", b, a, Major)
@@ -89,6 +97,7 @@ func TestSemverSensitiveVersions(t *testing.T) {
 
 	a = Version{"1.0.0", Semver}
 	b = Version{"1.0.1", Semver}
+
 	shouldBeFalse, _ = b.MoreSensitivelyRecentThan(a, Major)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v should not be more recent that version %v with sensitivity %v", b, a, Major)
@@ -111,6 +120,7 @@ func TestSemverSensitiveVersions(t *testing.T) {
 
 	a = Version{"6.21.0", Semver}
 	b = Version{"8.1.8", Semver}
+
 	shouldBeTrue, _ = b.MoreSensitivelyRecentThan(a, Minor)
 	if shouldBeTrue != true {
 		t.Errorf("Version %v should be more recent that version %v with sensitivity %v", b, a, Minor)
@@ -120,14 +130,17 @@ func TestSemverSensitiveVersions(t *testing.T) {
 func TestAlphaVersions(t *testing.T) {
 	a := Version{"20180101-commitid", Alpha}
 	b := Version{"20180505-commitid", Alpha}
+
 	shouldBeFalse, _ := a.MoreRecentThan(b)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", a, b)
 	}
+
 	shouldBeTrue, _ := b.MoreRecentThan(a)
 	if shouldBeTrue == false {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", b, a)
 	}
+
 	shouldBeFalse, _ = a.MoreRecentThan(a)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent than itself; it should not be", a)
@@ -137,10 +150,12 @@ func TestAlphaVersions(t *testing.T) {
 func TestRandomVersions(t *testing.T) {
 	a := Version{"ami-09bbefc07310f7914", Random}
 	b := Version{"ami-0199284372364b02a", Random}
+
 	shouldBeTrue, _ := b.MoreRecentThan(a)
 	if shouldBeTrue == false {
 		t.Errorf("Version %v is more recent that version %v; should be the opposite", b, a)
 	}
+
 	shouldBeFalse, _ := a.MoreRecentThan(a)
 	if shouldBeFalse == true {
 		t.Errorf("Version %v is more recent than itself; it should not be", a)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/zeitgeist
 
-go 1.12
+go 1.15
 
 require (
 	github.com/Masterminds/semver v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pluies/zeitgeist
+module sigs.k8s.io/zeitgeist
 
 go 1.12
 

--- a/upstreams/ami.go
+++ b/upstreams/ami.go
@@ -82,7 +82,7 @@ func (upstream AMI) LatestVersion() (string, error) {
 	log.Debugf("Matched AMIs:\n%s", images)
 
 	if len(images) < 1 {
-		return "", fmt.Errorf("No AMI found for upstream %s", upstream)
+		return "", fmt.Errorf("no AMI found for upstream %s", upstream)
 	}
 
 	latestImage := images[0]

--- a/upstreams/ami.go
+++ b/upstreams/ami.go
@@ -46,7 +46,8 @@ type AMI struct {
 //
 // Authentication
 //
-// Authentication is provided by the standard AWS credentials use the standard `~/.aws/config` and `~/.aws/credentials` files, and support environment variables.
+// Authentication is provided by the standard AWS credentials use the standard
+// `~/.aws/config` and `~/.aws/credentials` files, and support environment variables.
 // See AWS documentation for more details:
 // https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html
 func (upstream AMI) LatestVersion() (string, error) {
@@ -75,6 +76,7 @@ func (upstream AMI) LatestVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	images := result.Images
 
 	// Sort images by creation time, so we can return the latest

--- a/upstreams/ami_test.go
+++ b/upstreams/ami_test.go
@@ -25,10 +25,12 @@ func TestAMIHappyPath(t *testing.T) {
 		Owner: "amazon",
 		Name:  "amazon-eks-node-1.13-*",
 	}
+
 	latestVersion, err := ami.LatestVersion()
 	if err != nil {
 		t.Errorf("Failed AMI happy path test: %v", err)
 	}
+
 	if latestVersion == "" {
 		t.Errorf("Got an empty latestVersion")
 	}
@@ -40,6 +42,7 @@ func TestAMIDoesntExist(t *testing.T) {
 		Owner: "amazon",
 		Name:  fakeAmi,
 	}
+
 	_, err := ami.LatestVersion()
 	if err == nil {
 		t.Errorf("Found a latest version for unknown AMI: %s", fakeAmi)

--- a/upstreams/dummy_test.go
+++ b/upstreams/dummy_test.go
@@ -24,15 +24,19 @@ import (
 
 func TestDummy(t *testing.T) {
 	var u Dummy
+
 	input := []byte("flavour: dummy")
+
 	err := yaml.Unmarshal(input, &u)
 	if err != nil {
 		t.Errorf("Failed to deserialise valid yaml:\n%s\nError: %v", input, err)
 	}
+
 	v, err := u.LatestVersion()
 	if err != nil {
 		t.Errorf("Failed to get dummy latest version: %v", err)
 	}
+
 	if v != "1.0.0" {
 		t.Errorf("Dummy latest version isn't 1.0.0: %s", v)
 	}

--- a/upstreams/github.go
+++ b/upstreams/github.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const resultsPerPage = 30
+
 // Github upstream representation
 type Github struct {
 	UpstreamBase `mapstructure:",squash"`
@@ -40,24 +42,32 @@ type Github struct {
 
 func getClient() *github.Client {
 	var client *github.Client
+
 	accessToken := os.Getenv("GITHUB_ACCESS_TOKEN")
 	if accessToken != "" {
 		log.Debugf("GitHub Access Token provided")
+
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 		tc := oauth2.NewClient(context.Background(), ts)
 		client = github.NewClient(tc)
 	} else {
-		log.Warnf("No GitHub Access Token provided, might run into API limits. Set an access token with the GITHUB_ACCESS_TOKEN env var.")
+		log.Warnf(
+			`No GitHub Access Token provided, might run into API limits.
+			Set an access token with the GITHUB_ACCESS_TOKEN env var.`,
+		)
 		client = github.NewClient(nil)
 	}
+
 	return client
 }
 
-// LatestVersion returns the latest non-draft, non-prerelease Github Release for the given repository (depending on the Constraints if set).
+// LatestVersion returns the latest non-draft, non-prerelease Github Release
+// for the given repository (depending on the Constraints if set).
 //
 // Authentication
 //
-// The Github API allows unauthenticated requests, but the API limits are very strict: https://developer.github.com/v3/#rate-limiting
+// The Github API allows unauthenticated requests, but the API limits are very
+// strict: https://developer.github.com/v3/#rate-limiting
 //
 // To authenticate your requests, use the GITHUB_ACCESS_TOKEN environment variable.
 func (upstream Github) LatestVersion() (string, error) {
@@ -67,8 +77,12 @@ func (upstream Github) LatestVersion() (string, error) {
 
 func latestVersion(upstream Github, getClient func() *github.Client) (string, error) {
 	client := getClient()
+
 	if !strings.Contains(upstream.URL, "/") {
-		return "", fmt.Errorf("invalid github repo: %v\nGithub repo should be in the form owner/repo, e.g. kubernetes/kubernetes", upstream.URL)
+		return "", fmt.Errorf(
+			"invalid github repo: %v\nGithub repo should be in the form owner/repo, e.g. kubernetes/kubernetes",
+			upstream.URL,
+		)
 	}
 
 	semverConstraints := upstream.Constraints
@@ -76,6 +90,7 @@ func latestVersion(upstream Github, getClient func() *github.Client) (string, er
 		// If no range is passed, just use the broadest possible range
 		semverConstraints = ">= 0.0.0"
 	}
+
 	expectedRange, err := semver.ParseRange(semverConstraints)
 	if err != nil {
 		return "", fmt.Errorf("invalid semver constraints range: %v", upstream.Constraints)
@@ -84,7 +99,7 @@ func latestVersion(upstream Github, getClient func() *github.Client) (string, er
 	splitURL := strings.Split(upstream.URL, "/")
 	owner := splitURL[0]
 	repo := splitURL[1]
-	opt := &github.ListOptions{PerPage: 30}
+	opt := &github.ListOptions{PerPage: resultsPerPage}
 
 	// We'll need to fetch all releases, as Github doesn't provide sorting options.
 	// If we don't do that, we risk running into the case where for example:
@@ -92,16 +107,19 @@ func latestVersion(upstream Github, getClient func() *github.Client) (string, er
 	// - A bugfix 1.0.1 gets released
 	// - Now the "latest" (date-wise) release is not the highest semver, and not necessarily the one we want
 	var releases []*github.RepositoryRelease
+
 	for {
 		releasesInPage, resp, err := client.Repositories.ListReleases(context.Background(), owner, repo, opt)
 		if err != nil {
 			return "", fmt.Errorf("cannot list releases for repository %v/%v, error: %v", owner, repo, err)
 		}
+
 		releases = append(releases, releasesInPage...)
 		// Pagination handling: if there's a next page, try it too
 		if resp.NextPage == 0 {
 			break
 		}
+
 		opt.Page = resp.NextPage
 	}
 
@@ -109,11 +127,14 @@ func latestVersion(upstream Github, getClient func() *github.Client) (string, er
 		if release.TagName == nil {
 			log.Debugf("Skipping release without TagName")
 		}
+
 		tag := *release.TagName
+
 		if release.Draft != nil && *release.Draft {
 			log.Debugf("Skipping draft release: %v\n", tag)
 			continue
 		}
+
 		if release.Prerelease != nil && *release.Prerelease {
 			log.Debugf("Skipping prerelease release: %v\n", tag)
 			continue
@@ -129,6 +150,7 @@ func latestVersion(upstream Github, getClient func() *github.Client) (string, er
 		}
 
 		log.Debugf("Found latest matching release: %v\n", version)
+
 		return version.String(), nil
 	}
 

--- a/upstreams/github.go
+++ b/upstreams/github.go
@@ -40,21 +40,19 @@ type Github struct {
 	Constraints string
 }
 
+// TODO: Consider reusing the kubernetes/release GitHub client here instead
 func getClient() *github.Client {
 	var client *github.Client
 
 	accessToken := os.Getenv("GITHUB_ACCESS_TOKEN")
 	if accessToken != "" {
-		log.Debugf("GitHub Access Token provided")
+		log.Debugf("GitHub access token provided")
 
 		ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 		tc := oauth2.NewClient(context.Background(), ts)
 		client = github.NewClient(tc)
 	} else {
-		log.Warnf(
-			`No GitHub Access Token provided, might run into API limits.
-			Set an access token with the GITHUB_ACCESS_TOKEN env var.`,
-		)
+		log.Warnf("Set the GITHUB_ACCESS_TOKEN env var to avoid API limits")
 		client = github.NewClient(nil)
 	}
 

--- a/upstreams/github_test.go
+++ b/upstreams/github_test.go
@@ -26,17 +26,22 @@ import (
 
 func TestGetClient(t *testing.T) {
 	var client *github.Client
+
 	currentAccessToken := os.Getenv("GITHUB_ACCESS_TOKEN")
 	os.Unsetenv("GITHUB_ACCESS_TOKEN")
+
 	client = getClient()
 	if client == nil {
 		t.Errorf("Could not get a Github client (without access token)")
 	}
+
 	os.Setenv("GITHUB_ACCESS_TOKEN", "test")
+
 	client = getClient()
 	if client == nil {
 		t.Errorf("Could not get a Github client (with \"test\" access token)")
 	}
+
 	os.Setenv("GITHUB_ACCESS_TOKEN", currentAccessToken)
 }
 
@@ -47,6 +52,7 @@ func TestUnserialiseGithub(t *testing.T) {
 
 	for _, valid := range validYamls {
 		var u Github
+
 		err := yaml.Unmarshal([]byte(valid), &u)
 		if err != nil {
 			t.Errorf("Failed to deserialise valid yaml:\n%s", valid)
@@ -56,10 +62,12 @@ func TestUnserialiseGithub(t *testing.T) {
 
 func TestInvalidValues(t *testing.T) {
 	var err error
+
 	invalidURL := "test"
 	gh := Github{
 		URL: invalidURL,
 	}
+
 	_, err = gh.LatestVersion()
 	if err == nil {
 		t.Errorf("Should fail on invalid URL:\n%s", invalidURL)
@@ -70,6 +78,7 @@ func TestInvalidValues(t *testing.T) {
 		URL:         "test/test",
 		Constraints: invalidConstraint,
 	}
+
 	_, err = gh2.LatestVersion()
 	if err == nil {
 		t.Errorf("Should fail on invalid Constraint:\n%s", invalidConstraint)
@@ -80,6 +89,7 @@ func TestWrongRepository(t *testing.T) {
 	gh := Github{
 		URL: "Pluies/doesnotexist",
 	}
+
 	_, err := gh.LatestVersion()
 	if err == nil {
 		t.Errorf("Should fail on repository that does not exist")
@@ -90,10 +100,12 @@ func TestHappyPath(t *testing.T) {
 	gh := Github{
 		URL: "helm/helm",
 	}
+
 	latestVersion, err := gh.LatestVersion()
 	if err != nil {
 		t.Errorf("Failed Github happy path test: %v", err)
 	}
+
 	if latestVersion == "" {
 		t.Errorf("Got an empty latestVersion")
 	}

--- a/upstreams/helm.go
+++ b/upstreams/helm.go
@@ -51,7 +51,7 @@ type Helm struct {
 var cache map[string]*repo.IndexFile
 
 // getIndex returns the index for the given repository, and caches it for subsequent calls
-func getIndex(c repo.Entry) (*repo.IndexFile, error) {
+func getIndex(c *repo.Entry) (*repo.IndexFile, error) {
 	// Check cache first
 	if cache == nil {
 		// No cache: initialise it
@@ -71,7 +71,7 @@ func getIndex(c repo.Entry) (*repo.IndexFile, error) {
 	}
 	defer os.Remove(tempIndexFile.Name())
 
-	r, err := repo.NewChartRepository(&c, getter.All(environment.EnvSettings{}))
+	r, err := repo.NewChartRepository(c, getter.All(environment.EnvSettings{}))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func getIndex(c repo.Entry) (*repo.IndexFile, error) {
 // Authentication
 //
 // Authentication is passed through parameters on the upstream, matching the ones you'd pass to Helm directly.
-func (upstream Helm) LatestVersion() (string, error) {
+func (upstream *Helm) LatestVersion() (string, error) {
 	log.Debugf("Using Helm upstream")
 
 	repoURL := upstream.Repo
@@ -113,7 +113,7 @@ func (upstream Helm) LatestVersion() (string, error) {
 	}
 
 	// Get the index
-	index, err := getIndex(entry)
+	index, err := getIndex(&entry)
 	if err != nil {
 		return "", err
 	}

--- a/upstreams/helm.go
+++ b/upstreams/helm.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
+
 	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm/environment"
 	"k8s.io/helm/pkg/repo"
@@ -75,7 +76,7 @@ func getIndex(c repo.Entry) (*repo.IndexFile, error) {
 		return nil, err
 	}
 	if err := r.DownloadIndexFile(tempIndexFile.Name()); err != nil {
-		return nil, fmt.Errorf("Looks like %q is not a valid chart repository or cannot be reached: %s", c.URL, err)
+		return nil, fmt.Errorf("looks like %q is not a valid chart repository or cannot be reached: %s", c.URL, err)
 	}
 	index, err := repo.LoadIndexFile(tempIndexFile.Name())
 	if err != nil {

--- a/upstreams/helm_test.go
+++ b/upstreams/helm_test.go
@@ -24,14 +24,17 @@ func TestHelmHappyPath(t *testing.T) {
 	helm := Helm{
 		Name: "fluentd",
 	}
+
 	helm1 := Helm{
 		Name:        "fluentd",
 		Constraints: "< 2.0.0",
 	}
+
 	latestVersion, err := helm.LatestVersion()
 	if err != nil {
 		t.Errorf("Failed Helm happy path test: %v", err)
 	}
+
 	if latestVersion == "" {
 		t.Errorf("Got an empty latestVersion")
 	}
@@ -40,6 +43,7 @@ func TestHelmHappyPath(t *testing.T) {
 	if err1 != nil {
 		t.Errorf("Failed Helm happy path test: %v", err1)
 	}
+
 	if latestVersion1 == "" {
 		t.Errorf("Got an empty latestVersion")
 	}
@@ -54,6 +58,7 @@ func TestHelmBrokenRepo(t *testing.T) {
 		Repo: "https://example.com/",
 		Name: "fluentd",
 	}
+
 	_, err := helm.LatestVersion()
 	if err == nil {
 		t.Errorf("Should have failed on broken repo")
@@ -65,6 +70,7 @@ func TestHelmBadChart(t *testing.T) {
 		Repo: "stable",
 		Name: "this-chart-does-not-exist",
 	}
+
 	_, err := helm.LatestVersion()
 	if err == nil {
 		t.Errorf("Should have failed on broken chart")
@@ -77,6 +83,7 @@ func TestHelmBadConstraint(t *testing.T) {
 		Name:        "fluentd",
 		Constraints: ">2500.0.0",
 	}
+
 	_, err := helm.LatestVersion()
 	if err == nil {
 		t.Errorf("Should have failed on bad constraint")

--- a/upstreams/upstreams.go
+++ b/upstreams/upstreams.go
@@ -36,7 +36,7 @@ type UpstreamBase struct {
 // LatestVersion will always return an error.
 // UpstreamBase is only used to determine which actual upstream needs to be called, so it cannot return a sensible value
 func (u *UpstreamBase) LatestVersion() (string, error) {
-	return "", errors.New("Cannot determine latest version for UpstreamBase")
+	return "", errors.New("cannot determine latest version for UpstreamBase")
 }
 
 // UpstreamFlavour is an enum of all supported upstreams and their string representation

--- a/upstreams/upstreams_test.go
+++ b/upstreams/upstreams_test.go
@@ -24,11 +24,14 @@ import (
 
 func TestUpstreamBaseLatestVersion(t *testing.T) {
 	var u UpstreamBase
+
 	input := []byte("flavour: dummy")
+
 	err := yaml.Unmarshal(input, &u)
 	if err != nil {
 		t.Errorf("Failed to deserialise valid yaml:\n%s\nError: %v", input, err)
 	}
+
 	_, err = u.LatestVersion()
 	if err == nil {
 		t.Errorf("LatestVersion on UpstreamBase should return an error")

--- a/zeitgeist.go
+++ b/zeitgeist.go
@@ -37,7 +37,7 @@ var (
 
 // Initialise logging level based on LOG_LEVEL env var, or the --verbose flag.
 // Defaults to info
-func initLogging(verbose bool, json bool) {
+func initLogging(verbose, json bool) {
 	logLevelStr, ok := os.LookupEnv("LOG_LEVEL")
 	if !ok {
 		if verbose {

--- a/zeitgeist.go
+++ b/zeitgeist.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pluies/zeitgeist/dependencies"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	"sigs.k8s.io/zeitgeist/dependencies"
 )
 
 // Variables set by GoReleaser on release

--- a/zeitgeist.go
+++ b/zeitgeist.go
@@ -31,8 +31,8 @@ import (
 // Variables set by GoReleaser on release
 var (
 	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	commit  = "none"    // nolint: deadcode,gochecknoglobals,unused,varcheck
+	date    = "unknown" // nolint: deadcode,gochecknoglobals,unused,varcheck
 )
 
 // Initialise logging level based on LOG_LEVEL env var, or the --verbose flag.
@@ -129,6 +129,7 @@ func main() {
 	}
 
 	// Default action when no action is passed: display the help
+	// nolint: gocritic
 	app.Action = func(c *cli.Context) error {
 		return cli.ShowAppHelp(c)
 	}

--- a/zeitgeist.go
+++ b/zeitgeist.go
@@ -46,25 +46,32 @@ func initLogging(verbose, json bool) {
 			logLevelStr = "info"
 		}
 	}
+
 	logLevel, err := log.ParseLevel(logLevelStr)
 	if err != nil {
 		log.Fatalf("Invalid LOG_LEVEL: %v", logLevelStr)
 	}
+
 	log.SetLevel(logLevel)
+
 	if json {
 		log.SetFormatter(&log.JSONFormatter{})
 	} else {
-		log.SetFormatter(&log.TextFormatter{
-			FullTimestamp:          true,
-			DisableLevelTruncation: true,
-		})
+		log.SetFormatter(
+			&log.TextFormatter{
+				FullTimestamp:          true,
+				DisableLevelTruncation: true,
+			},
+		)
 	}
 }
 
 func main() {
-	var verbose bool
-	var json bool
-	var config string
+	var (
+		verbose bool
+		json    bool
+		config  string
+	)
 
 	app := cli.NewApp()
 	app.Name = "zeitgeist"
@@ -88,6 +95,7 @@ func main() {
 			Destination: &config,
 		},
 	}
+
 	app.Commands = []cli.Command{
 		{
 			Name:    "validate",


### PR DESCRIPTION
#### What type of PR is this?

/kind feature cleanup
/area dependency

#### What this PR does / why we need it:

- Update module references and imports to sigs.k8s.io/zeitgeist
- Update to go1.15.1
- Add .golangci.yml config
- lint: Initial sweep to fix minor warnings
- lint: Fix hugeParam warnings
- lint: Fix readability warnings, like 'lll' and 'wsl'
- upstreams/github: Add note about using GitHub client from k/release
- dependencies: Improve some error message output
- Dockerfile: Use distroless:static-debian10 for production image
- lint: Add nolint comments
- dependencies/versions_test: Add nolints for errcheck

Signed-off-by: Stephen Augustus

/assign @Pluies @saschagrunert @hasheddan @cpanato 
cc: @kubernetes/release-engineering

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

~The first commits add [k/repo-infra@v0.1.1](https://github.com/kubernetes/repo-infra/releases/tag/v0.1.0) as a sub-tree to save us from having to rewrite a bunch of verify scripts.~

Hmmmm, the more I stare at k/repo-infra, the more I see so much of the update/verify niceties are tied to using bazel, and I'm not sure we want to add yet another repo under bazel management.

I've dropped those commits.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Update module references and imports to sigs.k8s.io/zeitgeist
- Update to go1.15.1
- Dockerfile: Use distroless:static-debian10 for production image
```
