### PR TITLE
aws: refactor aws tests and client

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -75,8 +75,10 @@ func init() {
 // RunValidate is the function invoked by 'krel gcbmgr', responsible for
 // submitting release jobs to GCB
 func RunValidate(opts *ValidateOptions) error {
+	client := dependencies.NewClient()
+
 	if opts.remote {
-		updates, err := dependencies.RemoteCheck(opts.config)
+		updates, err := client.RemoteCheck(opts.config)
 		if err != nil {
 			return errors.Wrap(err, "check remote dependencies")
 		}
@@ -86,5 +88,5 @@ func RunValidate(opts *ValidateOptions) error {
 		}
 	}
 
-	return dependencies.LocalCheck(opts.config)
+	return client.LocalCheck(opts.config)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200930145003-4acb6c075d10
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Was checking out the code and running the tests locally to add a new feature and then I realize that the AWS tests were very attached to an AWS real configuration to run it when running the tests locally without any AWS credentials the tests always fail.

This PR adds a small refactor to be able to mock the AWS tests to not be dependent on real things.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
aws: refactor aws tests and client
```

/assign @justaugustus @saschagrunert 