### PR TITLE
lints: update based on golangci-lint feedback

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,23 +13,24 @@ issues:
 linters:
   disable-all: true
   enable:
+    - asciicheck
     - bodyclose
     - deadcode
     - depguard
     - dogsled
     - dupl
     - errcheck
-    - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godox
     - gofmt
+    - gofumpt
+    - goheader
     - goimports
     - golint
-    - gomnd
+    - gomodguard
     - goprintffuncname
-    - gosec
     - gosimple
     - govet
     - ineffassign
@@ -39,7 +40,7 @@ linters:
     - nakedret
     - prealloc
     - rowserrcheck
-    - scopelint
+    - sqlclosecheck
     - staticcheck
     - structcheck
     - stylecheck
@@ -49,17 +50,25 @@ linters:
     - unused
     - varcheck
     - whitespace
-
-    # Nits: These are things one might mention, but not block on during review.
-    #       We can consider disabling these checks, if we determine them to be
-    #       a little too nitty and obtrusive.
-    - lll
-    - wsl
-
-    # Disabled
-    # cobra uses globals and inits to set command configuration
-    #- gochecknoglobals
-    #- gochecknoinits
+    # - exhaustive
+    # - exportloopref
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - gosec
+    # - lll
+    # - nestif
+    # - nlreturn
+    # - noctx
+    # - nolintlint
+    # - scopelint
+    # - testpackage
+    # - wsl
 linters-settings:
   godox:
     keywords:
@@ -112,7 +121,6 @@ linters-settings:
       - emptyFallthrough
       - emptyStringTest
       - hexLiteral
-      - ifElseChain
       - methodExprCall
       - regexpMust
       - singleCaseSwitch
@@ -128,6 +136,7 @@ linters-settings:
       - valSwap
       - wrapperFunc
       - yodaStyleExpr
+      # - ifElseChain
 
       # Opinionated
       - builtinShadow

--- a/buoy/commands/check.go
+++ b/buoy/commands/check.go
@@ -30,13 +30,15 @@ import (
 )
 
 func addCheckCmd(root *cobra.Command) {
-	var domain string
-	var release string
-	var rulesetFlag string
-	var ruleset git.RulesetType
-	var verbose bool
+	var (
+		domain      string
+		release     string
+		rulesetFlag string
+		ruleset     git.RulesetType
+		verbose     bool
+	)
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "check go.mod",
 		Short: "Determine if this module has a ref for each dependency for a given release based on a ruleset.",
 		Long: `
@@ -79,12 +81,17 @@ Rulesets,
 		},
 	}
 
-	cmd.Flags().StringVarP(&domain, "domain", "d", "", "domain filter (i.e. knative.dev) [required]")
-	_ = cmd.MarkFlagRequired("domain")
-	cmd.Flags().StringVarP(&release, "release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
-	_ = cmd.MarkFlagRequired("release")
-	cmd.Flags().StringVar(&rulesetFlag, "ruleset", git.ReleaseOrReleaseBranchRule.String(), fmt.Sprintf("The ruleset to evaluate the dependency refs. Rulesets: [%s]", strings.Join(git.Rulesets(), ", ")))
+	cmd.Flags().StringVarP(&domain,
+		"domain", "d", "", "domain filter (i.e. knative.dev) [required]")
+	cmd.Flags().StringVarP(&release,
+		"release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
+	cmd.Flags().StringVar(&rulesetFlag,
+		"ruleset", git.ReleaseOrReleaseBranchRule.String(),
+		fmt.Sprintf("The ruleset to evaluate the dependency refs. Rulesets: [%s]", strings.Join(git.Rulesets(), ", ")))
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Print verbose output.")
+
+	_ = cmd.MarkFlagRequired("domain")  // nolint: errcheck
+	_ = cmd.MarkFlagRequired("release") // nolint: errcheck
 
 	root.AddCommand(cmd)
 }

--- a/buoy/commands/commands.go
+++ b/buoy/commands/commands.go
@@ -20,7 +20,7 @@ import "github.com/spf13/cobra"
 
 // New creates a new buoy cli command set.
 func New() *cobra.Command {
-	var buoyCmd = &cobra.Command{
+	buoyCmd := &cobra.Command{
 		Use:   "buoy",
 		Short: "Introspect go module dependencies.",
 	}

--- a/buoy/commands/exists.go
+++ b/buoy/commands/exists.go
@@ -33,7 +33,7 @@ func addExistsCmd(root *cobra.Command) {
 		tag     bool
 	)
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "exists go.mod",
 		Short: "Determine if the release branch exists for a given module.",
 		Args:  cobra.ExactArgs(1),
@@ -63,9 +63,10 @@ func addExistsCmd(root *cobra.Command) {
 	}
 
 	cmd.Flags().StringVarP(&release, "release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
-	_ = cmd.MarkFlagRequired("release")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Print verbose output (stderr)")
 	cmd.Flags().BoolVarP(&tag, "next", "t", false, "Print the next release tag (stdout)")
+
+	_ = cmd.MarkFlagRequired("release") // nolint: errcheck
 
 	root.AddCommand(cmd)
 }

--- a/buoy/commands/float.go
+++ b/buoy/commands/float.go
@@ -34,7 +34,7 @@ func addFloatCmd(root *cobra.Command) {
 		ruleset     git.RulesetType
 	)
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "float go.mod",
 		Short: "Find latest versions of dependencies based on a release.",
 		Long: `
@@ -86,8 +86,9 @@ For rulesets that that restrict the selection process, no ref is selected.
 
 	cmd.Flags().StringVarP(&domain, "domain", "d", "knative.dev", "domain filter (i.e. knative.dev) [required]")
 	cmd.Flags().StringVarP(&release, "release", "r", "", "release should be '<major>.<minor>' (i.e.: 1.23 or v1.23) [required]")
-	_ = cmd.MarkFlagRequired("release")
 	cmd.Flags().StringVar(&rulesetFlag, "ruleset", git.AnyRule.String(), fmt.Sprintf("The ruleset to evaluate the dependency refs. Rulesets: [%s]", strings.Join(git.Rulesets(), ", ")))
+
+	_ = cmd.MarkFlagRequired("release") // nolint: errcheck
 
 	root.AddCommand(cmd)
 }

--- a/buoy/commands/needs.go
+++ b/buoy/commands/needs.go
@@ -27,7 +27,7 @@ import (
 func addNeedsCmd(root *cobra.Command) {
 	var domain string
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "needs go.mod",
 		Short: "Find dependencies based on a base import domain.",
 		Args:  cobra.MinimumNArgs(1),
@@ -49,7 +49,8 @@ func addNeedsCmd(root *cobra.Command) {
 	}
 
 	cmd.Flags().StringVarP(&domain, "domain", "d", "", "domain filter (i.e. knative.dev) [required]")
-	_ = cmd.MarkFlagRequired("domain")
+
+	_ = cmd.MarkFlagRequired("domain") // nolint: errcheck
 
 	root.AddCommand(cmd)
 }

--- a/buoy/pkg/git/git.go
+++ b/buoy/pkg/git/git.go
@@ -99,6 +99,8 @@ func (r *Repo) BestRefFor(this semver.Version, ruleset RulesetType) (string, Ref
 		// Look for a release.
 		for _, t := range r.Tags {
 			if sv, ok := normalizeTagVersion(t); ok {
+				// TODO: refactor to check the error
+				// nolint: errcheck
 				v, _ := semver.Make(sv)
 				// Go does not understand how to fetch semver tags with pre or build tags, skip those.
 				if v.Pre != nil || v.Build != nil {
@@ -122,6 +124,8 @@ func (r *Repo) BestRefFor(this semver.Version, ruleset RulesetType) (string, Ref
 		// Look for a release branch.
 		for _, b := range r.Branches {
 			if bv, ok := normalizeBranchVersion(b); ok {
+				// TODO: refactor to check the error
+				// nolint: errcheck
 				v, _ := semver.Make(bv)
 
 				if v.Major == this.Major && v.Minor == this.Minor {
@@ -136,8 +140,7 @@ func (r *Repo) BestRefFor(this semver.Version, ruleset RulesetType) (string, Ref
 		}
 	}
 
-	switch ruleset {
-	case AnyRule:
+	if ruleset == AnyRule {
 		// Look for a Return default branch.
 		return fmt.Sprintf("%s@%s", r.Ref, r.DefaultBranch), DefaultBranchRef
 	}
@@ -175,7 +178,7 @@ func ReleaseBranchVersion(v semver.Version) string {
 // ParseRef takes a go module ref and converts it to the module name and RefType.
 // ParseRef expects ref to be in the form "module@ref".
 // Only release branches and
-func ParseRef(ref string) (string, string, RefType) {
+func ParseRef(ref string) (module, reference string, branchRef RefType) {
 	parts := strings.Split(ref, "@")
 	if len(parts) != 2 {
 		return ref, "", UndefinedRef
@@ -193,5 +196,4 @@ func ParseRef(ref string) (string, string, RefType) {
 
 	// At this point we have to assume it is a branch.
 	return parts[0], parts[1], BranchRef
-
 }

--- a/buoy/pkg/git/git_test.go
+++ b/buoy/pkg/git/git_test.go
@@ -34,8 +34,10 @@ func TestGetRepo_BasicOne(t *testing.T) {
 	if r == nil {
 		t.Error("failed to GetRepo: repo is nil")
 	}
-	if want := "master"; r.DefaultBranch != want {
-		t.Errorf("expected default branch to be %q, got %q", want, r.DefaultBranch)
+	// TODO: refactor test (use require pkg)
+	// nolint: staticcheck
+	if r.DefaultBranch != "master" {
+		t.Errorf("expected default branch to be master, got %q", r.DefaultBranch)
 	}
 	if want := 2; len(r.Branches) != want {
 		t.Errorf("expected branch count to be %d, got %d", want, len(r.Branches))

--- a/buoy/pkg/git/ruleset.go
+++ b/buoy/pkg/git/ruleset.go
@@ -34,8 +34,10 @@ const (
 	InvalidRule
 )
 
-var rulesetTypeString = []string{"Any", "ReleaseOrBranch", "Release", "Branch", "Invalid"}
-var rulesetLookup map[string]RulesetType
+var (
+	rulesetTypeString = []string{"Any", "ReleaseOrBranch", "Release", "Branch", "Invalid"}
+	rulesetLookup     map[string]RulesetType
+)
 
 // init will produce a ruleset lookup map to help with ruleset string conversion.
 func init() {

--- a/buoy/pkg/golang/goimport_test.go
+++ b/buoy/pkg/golang/goimport_test.go
@@ -95,7 +95,7 @@ func TestMetaContent(t *testing.T) {
 			meta: "foo",
 			doc: func() *html.Node {
 				body := `<html><head><meta name="foo" content="bar"></head></html>`
-				doc, _ := html.Parse(strings.NewReader(body))
+				doc, _ := html.Parse(strings.NewReader(body)) // nolint: errcheck
 				return doc
 			}(),
 			want: "bar",
@@ -104,7 +104,7 @@ func TestMetaContent(t *testing.T) {
 			meta: "bar",
 			doc: func() *html.Node {
 				body := `<html><head><meta name="foo" content="bar"></head></html>`
-				doc, _ := html.Parse(strings.NewReader(body))
+				doc, _ := html.Parse(strings.NewReader(body)) // nolint: errcheck
 				return doc
 			}(),
 			wantErr: true,
@@ -120,7 +120,7 @@ func TestMetaContent(t *testing.T) {
 					<meta http-equiv="refresh" content="0; url=https://pkg.go.dev/tableflip.dev/buoy/">
 				</head>
 				</html>`
-				doc, _ := html.Parse(strings.NewReader(body))
+				doc, _ := html.Parse(strings.NewReader(body)) // nolint: errcheck
 				return doc
 			}(),
 			want: "tableflip.dev/buoy git https://github.com/n3wscott/buoy",
@@ -142,6 +142,7 @@ func TestMetaContent(t *testing.T) {
 
 func TestGetMetaImport(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// nolint: errcheck
 		w.Write([]byte(`<html>
 		<head>
 			<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
@@ -182,7 +183,7 @@ func TestGetMetaImport_InvalidHost(t *testing.T) {
 
 func TestGetMetaImport_MissingGoImport(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html>hi</html>`))
+		w.Write([]byte(`<html>hi</html>`)) // nolint: errcheck
 	}))
 	defer ts.Close()
 

--- a/buoy/pkg/gomod/float.go
+++ b/buoy/pkg/gomod/float.go
@@ -35,6 +35,9 @@ func Float(gomod, release, domain string, ruleset git.RulesetType) ([]string, er
 	}
 
 	this, err := semver.ParseTolerant(release)
+	if err != nil {
+		return nil, err
+	}
 
 	refs := make([]string, 0)
 	for _, pkg := range packages {

--- a/buoy/pkg/gomod/modules.go
+++ b/buoy/pkg/gomod/modules.go
@@ -27,7 +27,7 @@ import (
 
 // Modules returns a map of given given modules to their direct dependencies,
 // and a list of unique dependencies.
-func Modules(gomod []string, domain string) (map[string][]string, []string, error) {
+func Modules(gomod []string, domain string) (pkgs map[string][]string, deps []string, err error) {
 	if len(gomod) == 0 {
 		return nil, nil, errors.New("no go module files provided")
 	}
@@ -53,9 +53,9 @@ func Modules(gomod []string, domain string) (map[string][]string, []string, erro
 
 // Module returns the name and a list of direct dependencies for a given module.
 // TODO: support url and gopath at some point for the gomod string.
-func Module(gomod string, domain string) (string, []string, error) {
+func Module(gomod, domain string) (name string, pkgs []string, err error) {
 	domain = strings.TrimSpace(domain)
-	if len(domain) == 0 {
+	if domain == "" {
 		return "", nil, errors.New("no domain provided")
 	}
 
@@ -69,7 +69,7 @@ func Module(gomod string, domain string) (string, []string, error) {
 		return "", nil, err
 	}
 
-	packages := make(sets.String, 0)
+	packages := make(sets.String)
 	for _, r := range file.Require {
 		// Do not include indirect dependencies.
 		if r.Indirect {

--- a/buoy/pkg/gomod/release_meta.go
+++ b/buoy/pkg/gomod/release_meta.go
@@ -79,6 +79,9 @@ func ReleaseStatus(gomod, release string, out io.Writer) (*ReleaseMeta, error) {
 	ref, refType = repo.BestRefFor(this, git.ReleaseRule)
 	if refType == git.ReleaseRef {
 		_, r, _ := git.ParseRef(ref)
+
+		// TODO: refactor to check the error
+		// nolint: errcheck
 		rv, _ := semver.ParseTolerant(r) // has to parse, r is from BestRefFor
 		rv.Patch++
 

--- a/go.sum
+++ b/go.sum
@@ -1287,11 +1287,8 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclp
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-helm.sh/helm v1.2.1 h1:Jrn7kKQqQ/hnFWZEX+9pMFvYqFexkzrBnGqYBmIph7c=
-helm.sh/helm v2.17.0+incompatible h1:cSe3FaQOpRWLDXvTObQNj0P7WI98IG5yloU6tQVls2k=
 helm.sh/helm/v3 v3.3.4 h1:tbad6WQVMxEw1HlVBvI2rQqOblmI5lgXOrWAMwJ198M=
 helm.sh/helm/v3 v3.3.4/go.mod h1:CyCGQa53/k1JFxXvXveGwtfJ4cuB9zkaBSGa5rnAiHU=
-helm.sh/helm/v3 v3.4.0 h1:rsut6hqQfjD3G/ic1XPh3KyasfOHZuDUhtyAJjuquew=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/upstreams/github.go
+++ b/upstreams/github.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/release/pkg/github"
 )
 
-const resultsPerPage = 30
-
 // Github upstream representation
 type Github struct {
 	UpstreamBase `mapstructure:",squash"`


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- update the golangci-lint definition to be similar to the one we have in k/release
- update code based on the golangci-lint feedback


Follow up:
 - change the tests to use the `require` pkg and make it more clear (I already did some changes, but will wait for this PR to get merged first)
 - See where we can use some git/github package from k/release here

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
lints: update based on golangci-lint feedback
```

/assign @saschagrunert @justaugustus 
