### PR TITLE
add support to check for commits on branches in git repos

### DIFF
--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -28,7 +28,7 @@ import (
 const (
 	// TokenEnvKey is the default GitLab token environemt variable key
 	TokenEnvKey = "GITLAB_TOKEN"
-	// PrivateTokenEnvKey is the priavete GitLAb token environemt variable key
+	// PrivateTokenEnvKey is the private GitLab token environment variable key
 	PrivateTokenEnvKey = "GITLAB_PRIVATE_TOKEN"
 	apiVersionPath     = "api/v4/"
 )
@@ -48,6 +48,9 @@ type Client interface {
 	ListReleases(
 		string, string, *gitlab.ListReleasesOptions,
 	) ([]*gitlab.Release, *gitlab.Response, error)
+	ListBranches(
+		string, string, *gitlab.ListBranchesOptions,
+	) ([]*gitlab.Branch, *gitlab.Response, error)
 }
 
 // New creates a new default GitLab client. Tokens set via the $GITLAB_TOKEN
@@ -101,6 +104,14 @@ func (g *gitlabClient) ListReleases(
 	return releases, resp, err
 }
 
+func (g *gitlabClient) ListBranches(
+	owner, repo string, opt *gitlab.ListBranchesOptions,
+) ([]*gitlab.Branch, *gitlab.Response, error) {
+	project := fmt.Sprintf("%s/%s", owner, repo)
+	branches, resp, err := g.Branches.ListBranches(project, opt)
+	return branches, resp, err
+}
+
 // SetClient can be used to manually set the internal GitLab client
 func (g *GitLab) SetClient(client Client) {
 	g.client = client
@@ -120,4 +131,12 @@ func (g *GitLab) Releases(owner, repo string) ([]*gitlab.Release, error) {
 	}
 
 	return allReleases, nil
+}
+
+func (g *GitLab) Branches(owner, repo string) ([]*gitlab.Branch, error) {
+	branches, _, err := g.client.ListBranches(owner, repo, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to retrieve Gitlab releases for %v/%v", owner, repo)
+	}
+	return branches, nil
 }

--- a/pkg/gitlab/gitlab_test.go
+++ b/pkg/gitlab/gitlab_test.go
@@ -46,6 +46,58 @@ func newSUTPrivate() (*gitlab.GitLab, *gitlabfakes.FakeClient) {
 	return sut, client
 }
 
+func TestBranchesSuccessEmpty(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+	client.ListBranchesReturns([]*gogitlab.Branch{}, nil, nil)
+
+	// When
+	res, err := sut.Branches("", "")
+
+	// Then
+	require.Nil(t, err)
+	require.Empty(t, res)
+}
+
+func TestPrivateBranchesSuccessEmpty(t *testing.T) {
+	// Given
+	sut, client := newSUTPrivate()
+	client.ListBranchesReturns([]*gogitlab.Branch{}, nil, nil)
+
+	// When
+	res, err := sut.Branches("", "")
+
+	// Then
+	require.Nil(t, err)
+	require.Empty(t, res)
+}
+
+func TestBranchesFailed(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+	client.ListBranchesReturns(nil, nil, errors.New("error"))
+
+	// When
+	res, err := sut.Branches("", "")
+
+	// Then
+	require.NotNil(t, err)
+	require.Nil(t, res, nil)
+}
+
+func TestPrivateBranchesFailed(t *testing.T) {
+	// Given
+	sut, client := newSUTPrivate()
+	client.ListBranchesReturns(nil, nil, errors.New("error"))
+
+	// When
+	res, err := sut.Branches("", "")
+
+	// Then
+	require.NotNil(t, err)
+	require.Nil(t, res, nil)
+}
+
 func TestReleasesSuccessEmpty(t *testing.T) {
 	// Given
 	sut, client := newSUT()

--- a/pkg/gitlab/gitlabfakes/fake_client.go
+++ b/pkg/gitlab/gitlabfakes/fake_client.go
@@ -26,8 +26,94 @@ type FakeClient struct {
 		result2 *gitlaba.Response
 		result3 error
 	}
+
+	ListBranchesStub        func(string, string, *gitlaba.ListBranchesOptions) ([]*gitlaba.Branch, *gitlaba.Response, error)
+	listBranchesMutex       sync.RWMutex
+	listBranchesArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *gitlaba.ListBranchesOptions
+	}
+	listBranchesReturns struct {
+		result1 []*gitlaba.Branch
+		result2 *gitlaba.Response
+		result3 error
+	}
+	listBranchesReturnsOnCall map[int]struct {
+		result1 []*gitlaba.Branch
+		result2 *gitlaba.Response
+		result3 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeClient) ListBranches(arg1 string, arg2 string, arg3 *gitlaba.ListBranchesOptions) ([]*gitlaba.Branch, *gitlaba.Response, error) {
+	fake.listBranchesMutex.Lock()
+	ret, specificReturn := fake.listBranchesReturnsOnCall[len(fake.listBranchesArgsForCall)]
+	fake.listBranchesArgsForCall = append(fake.listBranchesArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *gitlaba.ListBranchesOptions
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListBranches", []interface{}{arg1, arg2, arg3})
+	fake.listBranchesMutex.Unlock()
+	if fake.ListBranchesStub != nil {
+		return fake.ListBranchesStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.listBranchesReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListBranchesCallCount() int {
+	fake.listBranchesMutex.RLock()
+	defer fake.listBranchesMutex.RUnlock()
+	return len(fake.listBranchesArgsForCall)
+}
+
+func (fake *FakeClient) ListBranchesCalls(stub func(string, string, *gitlaba.ListBranchesOptions) ([]*gitlaba.Branch, *gitlaba.Response, error)) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = stub
+}
+
+func (fake *FakeClient) ListBranchesArgsForCall(i int) (string, string, *gitlaba.ListBranchesOptions) {
+	fake.listBranchesMutex.RLock()
+	defer fake.listBranchesMutex.RUnlock()
+	argsForCall := fake.listBranchesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) ListBranchesReturns(result1 []*gitlaba.Branch, result2 *gitlaba.Response, result3 error) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = nil
+	fake.listBranchesReturns = struct {
+		result1 []*gitlaba.Branch
+		result2 *gitlaba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListBranchesReturnsOnCall(i int, result1 []*gitlaba.Branch, result2 *gitlaba.Response, result3 error) {
+	fake.listBranchesMutex.Lock()
+	defer fake.listBranchesMutex.Unlock()
+	fake.ListBranchesStub = nil
+	if fake.listBranchesReturnsOnCall == nil {
+		fake.listBranchesReturnsOnCall = make(map[int]struct {
+			result1 []*gitlaba.Branch
+			result2 *gitlaba.Response
+			result3 error
+		})
+	}
+	fake.listBranchesReturnsOnCall[i] = struct {
+		result1 []*gitlaba.Branch
+		result2 *gitlaba.Response
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeClient) ListReleases(arg1 string, arg2 string, arg3 *gitlaba.ListReleasesOptions) ([]*gitlaba.Release, *gitlaba.Response, error) {

--- a/upstreams/github_test.go
+++ b/upstreams/github_test.go
@@ -73,6 +73,34 @@ func TestWrongRepository(t *testing.T) {
 	}
 }
 
+func TestNonExistentBranch(t *testing.T) {
+	gh := Github{
+		URL:    "helm/heml",
+		Branch: "branch_that_does_no_exists",
+	}
+
+	_, err := gh.LatestVersion()
+	if err == nil {
+		t.Errorf("Failed non existent branch test. Error should not be nil")
+	}
+}
+
+func TestBranchHappyPath(t *testing.T) {
+	gh := Github{
+		URL:    "helm/helm",
+		Branch: "master",
+	}
+
+	latestVersion, err := gh.LatestVersion()
+	if err != nil {
+		t.Errorf("Faield github branch happy path test: %v", err)
+	}
+
+	if latestVersion == "" {
+		t.Errorf("Got an empty latestVersion")
+	}
+}
+
 func TestHappyPath(t *testing.T) {
 	gh := Github{
 		URL: "helm/helm",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds support to check for new commits on a git branch for `github` and `gitlab` flavours.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #27 

or

None
-->

#### Special notes for your reviewer:
Example dependencies.yaml to use the new feature:
```yaml
dependencies:
- name: project_of_ineterest
  version: 79b5b78183f2585689780fbdef1395b06d05ed25
  scheme: random
  upstream:
    flavour: github
    url: prow-testing/test1
    branch: master
```
If the `branch` is specified the `version` is expected to be a commit hash. If not it reverts to the default behavior.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support to look for changes on a branch of a git repo
```
