### PR TITLE
support json and yaml format outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage.out
 .DS_Store
 dist/
 bin/
+.idea

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -112,6 +112,7 @@ func New() *cobra.Command {
 
 func AddCommands(topLevel *cobra.Command) {
 	addValidate(topLevel)
+	addExport(topLevel)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/commands/export.go
+++ b/commands/export.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/zeitgeist/dependency"
+)
+
+type OutputFormat string
+
+const (
+	YAML OutputFormat = "yaml"
+	JSON OutputFormat = "json"
+	LOG  OutputFormat = "log"
+)
+
+const defaultOutputFileName = "dependencies_output"
+
+type exportOptions struct {
+	rootOpts     *options
+	outputFormat string
+	outputFile   string
+}
+
+func (exo *exportOptions) setAndValidate() error {
+	if err := exo.rootOpts.setAndValidate(); err != nil {
+		return err
+	}
+
+	if exo.rootOpts.localOnly {
+		logrus.Warn("ignoring flag '--local-only'")
+	}
+
+	switch OutputFormat(exo.outputFormat) {
+	case YAML:
+	case JSON:
+	case LOG:
+	default:
+		return fmt.Errorf("unsuported output format")
+	}
+
+	if exo.outputFile != "" && OutputFormat(exo.outputFormat) == LOG {
+		logrus.Warnf("ignoring --output-file as --output-format is 'log'")
+	}
+
+	return nil
+}
+
+var exportOpts = &exportOptions{}
+
+func addExport(topLevel *cobra.Command) {
+	exo := exportOpts
+	exo.rootOpts = rootOpts
+
+	cmd := &cobra.Command{
+		Use:           "export",
+		Short:         "Export list of 'latest' upstream versions available",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE: func(*cobra.Command, []string) error {
+			if err := exo.setAndValidate(); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExport(exo)
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(
+		&exportOpts.outputFormat,
+		"output-format",
+		"log",
+		"format of the output. Supported values are 'log', 'json' and 'yaml'. If not provided it will default to printing log.",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&exportOpts.outputFile,
+		"output-file",
+		"",
+		"file to write output. Use only if --output-format is 'json' or 'yaml'. If not specified will default to dependency_output.(json|yaml).",
+	)
+
+	topLevel.AddCommand(cmd)
+}
+
+// runValidate is the function invoked by 'addValidate', responsible for
+// validating dependencies in a specified configuration file.
+func runExport(opts *exportOptions) error {
+	client := dependency.NewClient()
+
+	updates, err := client.RemoteExport(opts.rootOpts.configFile)
+	if err != nil {
+		return err
+	}
+
+	return output(opts, updates)
+}
+
+func output(opts *exportOptions, updates []dependency.VersionUpdate) error {
+	if OutputFormat(opts.outputFormat) == LOG {
+		return outputLog(updates)
+	}
+	return outputFile(opts, updates)
+}
+
+func outputLog(updates []dependency.VersionUpdate) error {
+	for _, update := range updates {
+		if update.Version == update.NewVersion {
+			logrus.Debugf(
+				"No update available for dependency %v: %v (latest: %v)\n",
+				update.Name,
+				update.Version,
+				update.NewVersion,
+			)
+		} else {
+			fmt.Printf(
+				"Update available for dependency %v: %v (current: %v)\n",
+				update.Name,
+				update.NewVersion,
+				update.Version,
+			)
+		}
+	}
+	return nil
+}
+
+func outputFile(opts *exportOptions, updates []dependency.VersionUpdate) error {
+	var outputFile string
+	if opts.outputFile != "" {
+		outputFile = opts.outputFile
+	} else {
+		outputFile = fmt.Sprintf("%v.%v", defaultOutputFileName, opts.outputFormat)
+	}
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open output file")
+	}
+	defer f.Close()
+
+	var b []byte
+	switch OutputFormat(opts.outputFormat) {
+	case YAML:
+		b, err = yaml.Marshal(updates)
+		if err != nil {
+			return err
+		}
+	case JSON:
+		b, err = json.Marshal(updates)
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, err := f.Write(b); err != nil {
+		return errors.Wrapf(err, "failed to write output")
+	}
+	return nil
+}

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -69,6 +69,28 @@ func TestDummyRemote(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestDummyRemoteExportWithoutUpdate(t *testing.T) {
+	client := NewClient()
+
+	updates, err := client.RemoteExport("../testdata/remote-dummy.yaml")
+	require.Nil(t, err)
+	require.NotEmpty(t, updates)
+	require.Equal(t, updates[0].Name, "example")
+	require.Equal(t, updates[0].Version, "1.0.0")
+	require.Equal(t, updates[0].NewVersion, "1.0.0")
+}
+
+func TestDummyRemoteExportWithUpdate(t *testing.T) {
+	client := NewClient()
+
+	updates, err := client.RemoteExport("../testdata/remote-dummy-with-update.yaml")
+	require.Nil(t, err)
+	require.NotEmpty(t, updates)
+	require.Equal(t, updates[0].Name, "example")
+	require.Equal(t, updates[0].Version, "0.0.1")
+	require.Equal(t, updates[0].NewVersion, "1.0.0")
+}
+
 func TestRemoteConstraint(t *testing.T) {
 	client := NewClient()
 

--- a/dependency/version.go
+++ b/dependency/version.go
@@ -39,6 +39,21 @@ const (
 	Random VersionScheme = "random"
 )
 
+type versionUpdateInfo struct {
+	name            string
+	current         Version
+	latest          Version
+	updateAvailable bool
+}
+
+// VersionUpdate represents the schema of the output format
+// The output format is dictated by exportOptions.outputFormat
+type VersionUpdate struct {
+	Name       string `yaml:"name" json:"name"`
+	Version    string `yaml:"version" json:"version"`
+	NewVersion string `yaml:"new_version" json:"new_version"`
+}
+
 // VersionSensitivity informs us on how to compare whether a version is more
 // recent than another, for example to only notify on new major versions
 // Only applicable to Semver versioning

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/oauth2 v0.0.0-20210112200429-01de73cf58bd
+	golang.org/x/tools v0.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	sigs.k8s.io/release-utils v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,9 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -523,8 +524,9 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6 h1:rbvTkL9AkFts1cgI78+gG6Yu1pwaqX6hjSJAatB78E4=
 golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/testdata/remote-dummy-with-update.yaml
+++ b/testdata/remote-dummy-with-update.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  - name: example
+    version: 0.0.1
+    upstream:
+      flavour: dummy
+      url: example/example


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change


#### What this PR does / why we need it:
This PR add support for formatted outputs.  
The following formats are supported:
* JSON
* YAML
* LOG (Default)

Zeitgiest can be used by other systems, like build systems, to form further actions on the outputs.  
Providing machine readable outputs allows zeitgeitst's outputs to be consumed by downstream settings.

Adds `--output-format` to specify the format of the output. Supported values are `yaml`, `json` and `log` (default). 
Adds `--output-file` to specify the file if format is `yaml` or `json`. Defaults to `dependencies_output.(yaml|json)`. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #21 #30 

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support for machine readable outputs. Supports JSON and YAML

```
