### PR TITLE
dependencies: Do not warn for every non-matched line in a scanned file

### DIFF
--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -176,16 +176,7 @@ func (c *Client) LocalCheck(dependencyFilePath, basePath string) error {
 						)
 
 						found = true
-
 						break
-					} else {
-						log.Warnf(
-							"Line %v matches expected regexp '%v', but not version '%v': %v",
-							lineNumber,
-							match,
-							dep.Version,
-							line,
-						)
 					}
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

This is noisy and unnecessarily alarming behavior.
Errors/warnings should only be expected when a dependency is missing
from a specified refPath.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
dependencies: Do not warn for every non-matched line in a scanned file
```
