### PR TITLE
commands: Init importable package for zeitgeist commands

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/* Zeitgeist is a language-agnostic dependency checker */
-
-package cmd
+package commands
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/release-utils/log"
@@ -40,28 +39,26 @@ var (
 	date    = "unknown" // nolint: deadcode,unused,varcheck
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:               "zeitgeist",
-	Short:             "Zeitgeist is a language-agnostic dependency checker",
-	PersistentPreRunE: initLogging,
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		logrus.Fatal(err)
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "zeitgeist",
+		Short:             "Zeitgeist is a language-agnostic dependency checker",
+		PersistentPreRunE: initLogging,
 	}
-}
 
-func init() {
-	rootCmd.PersistentFlags().StringVar(
+	cmd.PersistentFlags().StringVar(
 		&rootOpts.logLevel,
 		"log-level",
 		"info",
-		"the logging verbosity, either 'panic', 'fatal', 'error', 'warn', 'warning', 'info', 'debug' or 'trace'",
+		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
 	)
+
+	AddCommands(cmd)
+	return cmd
+}
+
+func AddCommands(topLevel *cobra.Command) {
+	// addValidate(topLevel)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -24,12 +24,10 @@ import (
 	"sigs.k8s.io/release-utils/log"
 )
 
-type rootOptions struct {
-	logLevel string
-}
+const defaultConfigFile = "dependencies.yaml"
 
 var (
-	rootOpts = &rootOptions{}
+	rootOpts = &options{}
 
 	// TODO: Implement these as a separate function or subcommand to avoid the
 	//       deadcode,unused,varcheck nolints
@@ -45,6 +43,35 @@ func New() *cobra.Command {
 		Short:             "Zeitgeist is a language-agnostic dependency checker",
 		PersistentPreRunE: initLogging,
 	}
+
+	// Submit types
+	cmd.PersistentFlags().BoolVar(
+		&rootOpts.local,
+		"local",
+		false,
+		"if specified, subcommands will only perform local checks",
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&rootOpts.remote,
+		"remote",
+		false,
+		"if specified, subcommands will query against remotes defined in the config",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&rootOpts.config,
+		"config",
+		defaultConfigFile,
+		"configuration file location",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&rootOpts.basePath,
+		"base-path",
+		"",
+		"base path to begin searching for dependencies (defaults to where the program was called from)",
+	)
 
 	cmd.PersistentFlags().StringVar(
 		&rootOpts.logLevel,

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -58,7 +58,7 @@ func New() *cobra.Command {
 }
 
 func AddCommands(topLevel *cobra.Command) {
-	// addValidate(topLevel)
+	addValidate(topLevel)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/commands/options.go
+++ b/commands/options.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+type options struct {
+	logLevel string
+	local    bool
+	remote   bool
+	config   string
+	basePath string
+}
+
+// setAndValidate sets some default options and verifies if options are valid
+func (o *options) setAndValidate() error {
+	logrus.Info("Validating zeitgeist options...")
+
+	if o.basePath != "" {
+		if _, err := os.Stat(o.basePath); os.IsNotExist(err) {
+			return err
+		}
+	} else {
+		dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+		if err != nil {
+			return err
+		}
+		o.basePath = dir
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -14,10 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/* Zeitgeist is a language-agnostic dependency checker */
+
 package main
 
-import "sigs.k8s.io/zeitgeist/cmd"
+import (
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/zeitgeist/commands"
+)
 
 func main() {
-	cmd.Execute()
+	if err := commands.New().Execute(); err != nil {
+		logrus.Fatalf("error during command execution: %v", err)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup design

#### What this PR does / why we need it:

Channeling @n3wscott a little, this PR:
- pushes commands into a separate package
- removes side effects from using `init()`
- promotes validate options to root level

This structure should make it a bit more pleasant to add commands (like the `export` command being proposed in https://github.com/kubernetes-sigs/zeitgeist/pull/31). 

Other examples:
- https://github.com/n3wscott/bujo
- https://github.com/kubernetes/enhancements/tree/master/pkg/kepctl

This is strictly code organization; no flags or functionality was changed, so this doesn't require a release note.

/assign @wilsonehusin @cpanato @ykakarap 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
