### PR TITLE
commands: Default to remote checks and introduce `--local-only` flag

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -45,18 +45,12 @@ func New() *cobra.Command {
 	}
 
 	// Submit types
-	cmd.PersistentFlags().BoolVar(
-		&rootOpts.local,
-		"local",
-		false,
-		"if specified, subcommands will only perform local checks",
-	)
 
 	cmd.PersistentFlags().BoolVar(
-		&rootOpts.remote,
-		"remote",
+		&rootOpts.localOnly,
+		"local-only",
 		false,
-		"if specified, subcommands will query against remotes defined in the config",
+		"if specified, subcommands will only perform local checks",
 	)
 
 	cmd.PersistentFlags().StringVar(
@@ -79,6 +73,38 @@ func New() *cobra.Command {
 		"info",
 		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
 	)
+
+	// START - Deprecated flags
+
+	// TODO: Remove in the next (post-v0.3.0) minor release
+	cmd.PersistentFlags().BoolVar(
+		&rootOpts.localOnly,
+		"local",
+		false,
+		"if specified, subcommands will only perform local checks",
+	)
+
+	// TODO: Remove in the next (post-v0.3.0) minor release
+	cmd.PersistentFlags().BoolVar(
+		&rootOpts.remote,
+		"remote",
+		false,
+		"if specified, subcommands will query against remotes defined in the config",
+	)
+
+	// nolint: errcheck
+	cmd.PersistentFlags().MarkDeprecated(
+		"local",
+		"and will be removed in a future release. Use --local-only instead.",
+	)
+
+	// nolint: errcheck
+	cmd.PersistentFlags().MarkDeprecated(
+		"remote",
+		"as remote checks now happen by default.",
+	)
+
+	// END - Deprecated flags
 
 	AddCommands(cmd)
 	return cmd

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -60,7 +60,7 @@ func New() *cobra.Command {
 	)
 
 	cmd.PersistentFlags().StringVar(
-		&rootOpts.config,
+		&rootOpts.configFile,
 		"config",
 		defaultConfigFile,
 		"configuration file location",

--- a/commands/options.go
+++ b/commands/options.go
@@ -33,7 +33,7 @@ type options struct {
 
 // setAndValidate sets some default options and verifies if options are valid
 func (o *options) setAndValidate() error {
-	logrus.Info("Validating zeitgeist options...")
+	logrus.Debug("Validating zeitgeist options...")
 
 	if o.basePath != "" {
 		if _, err := os.Stat(o.basePath); os.IsNotExist(err) {

--- a/commands/options.go
+++ b/commands/options.go
@@ -24,11 +24,16 @@ import (
 )
 
 type options struct {
+	// configuration options
+	local  bool
+	remote bool
+
+	// path options
+	basePath   string
+	configFile string
+
+	// command options
 	logLevel string
-	local    bool
-	remote   bool
-	config   string
-	basePath string
 }
 
 // setAndValidate sets some default options and verifies if options are valid

--- a/commands/options.go
+++ b/commands/options.go
@@ -25,8 +25,8 @@ import (
 
 type options struct {
 	// configuration options
-	local  bool
-	remote bool
+	localOnly bool
+	remote    bool
 
 	// path options
 	basePath   string

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -50,7 +50,7 @@ func runValidate(opts *options) error {
 	client := dependencies.NewClient()
 
 	if opts.remote {
-		updates, err := client.RemoteCheck(opts.config)
+		updates, err := client.RemoteCheck(opts.configFile)
 		if err != nil {
 			return errors.Wrap(err, "check remote dependencies")
 		}
@@ -60,5 +60,5 @@ func runValidate(opts *options) error {
 		}
 	}
 
-	return client.LocalCheck(opts.config, opts.basePath)
+	return client.LocalCheck(opts.configFile, opts.basePath)
 }

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -49,10 +49,14 @@ func addValidate(topLevel *cobra.Command) {
 func runValidate(opts *options) error {
 	client := dependencies.NewClient()
 
-	if opts.remote {
+	if opts.localOnly {
+		if err := client.LocalCheck(opts.configFile, opts.basePath); err != nil {
+			return errors.Wrap(err, "checking local dependencies")
+		}
+	} else {
 		updates, err := client.RemoteCheck(opts.configFile)
 		if err != nil {
-			return errors.Wrap(err, "check remote dependencies")
+			return errors.Wrap(err, "checking remote dependencies")
 		}
 
 		for _, update := range updates {
@@ -60,5 +64,5 @@ func runValidate(opts *options) error {
 		}
 	}
 
-	return client.LocalCheck(opts.configFile, opts.basePath)
+	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Addresses @wilsonehusin's feedback from https://github.com/kubernetes-sigs/zeitgeist/pull/36.

- commands: Move setAndValidate to Debug log level
- commands: Clarify that the config flag represents a path
- commands: Default to remote checks and introduce `--local-only` flag

  When a remote dependency is specified in a zeitgeist config file, we
  should always check for it, unless we explicitly request a local check.
  
  We also add the `--local-only` flag to clarify that a local check does
  not also check remotes.

  The following flags have been marked deprecated as a result:
  - `--local`
  - `--remote`

/assign @wilsonehusin @cpanato @ykakarap

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- commands: Default to remote checks and introduce `--local-only` flag

  When a remote dependency is specified in a zeitgeist config file, we
  should always check for it, unless we explicitly request a local check.
  
  We also add the `--local-only` flag to clarify that a local check does
  not also check remotes.

  The following flags have been marked deprecated as a result:
  - `--local`
  - `--remote`
```
