### PR TITLE
fix: container upstream

### DIFF
--- a/upstream/container.go
+++ b/upstream/container.go
@@ -68,7 +68,7 @@ func highestSemanticImageTag(upstream *Container) (string, error) {
 		orig   string         // original tag string
 		parsed semver.Version // parsed semver
 	}
-	var versions []semverWithOrig
+	versions := make([]semverWithOrig, 0, len(tags))
 	for _, tag := range tags {
 		parsed, err := semver.ParseTolerant(tag)
 		if err != nil {

--- a/upstream/container.go
+++ b/upstream/container.go
@@ -68,14 +68,14 @@ func highestSemanticImageTag(upstream *Container) (string, error) {
 	for _, tag := range tags {
 		// Try to match semver and range
 		version, err := semver.Parse(strings.Trim(tag, "v"))
-		// Try to match semver and range
 		if err != nil {
-			log.Debugf("Error parsing version %v (%v) as semver, cannot validate semver constraints", tag, err)
-		} else if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%v): %v\n", upstream.Constraints, tag)
+			log.Debugf("Error parsing version %s (%v) as semver, cannot validate semver constraints", tag, err)
 			continue
 		}
-
+		if !expectedRange(version) {
+			log.Debugf("Skipping release not matching range constraints (%s): %s\n", upstream.Constraints, tag)
+			continue
+		}
 		log.Debugf("Found latest matching tag: %v\n", version)
 		return version.String(), nil
 	}

--- a/upstream/container.go
+++ b/upstream/container.go
@@ -73,11 +73,11 @@ func highestSemanticImageTag(upstream *Container) (string, error) {
 			continue
 		}
 		if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%s): %s\n", upstream.Constraints, tag)
+			log.Debugf("Skipping release not matching range constraints (%s): %s", upstream.Constraints, tag)
 			continue
 		}
-		log.Debugf("Found latest matching tag: %v\n", version)
-		return version.String(), nil
+		log.Debugf("Found latest matching tag: %s", tag)
+		return tag, nil
 	}
 
 	return "", errors.Errorf("no potential tag found")

--- a/upstream/container.go
+++ b/upstream/container.go
@@ -18,7 +18,6 @@ package upstream
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -62,22 +61,38 @@ func highestSemanticImageTag(upstream *Container) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "retrieving Container tags")
 	}
+	log.Debugf("Found %d tags for %s...", len(tags), upstream.Registry)
 
-	sort.Sort(sort.Reverse(sort.StringSlice(tags)))
-
+	// parse semvers first so we can safely sort
+	type semverWithOrig struct {
+		orig   string         // original tag string
+		parsed semver.Version // parsed semver
+	}
+	var versions []semverWithOrig
 	for _, tag := range tags {
-		// Try to match semver and range
-		version, err := semver.Parse(strings.Trim(tag, "v"))
+		parsed, err := semver.ParseTolerant(tag)
 		if err != nil {
-			log.Debugf("Error parsing version %s (%v) as semver, cannot validate semver constraints", tag, err)
+			log.Debugf("Error parsing version %s (%v) as semver", tag, err)
 			continue
 		}
-		if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%s): %s", upstream.Constraints, tag)
+		versions = append(versions, semverWithOrig{
+			orig:   tag,
+			parsed: parsed,
+		})
+	}
+	// reverse sort, highest first
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[j].parsed.LT(versions[i].parsed)
+	})
+
+	// find first version matching constraints
+	for _, version := range versions {
+		if !expectedRange(version.parsed) {
+			log.Debugf("Skipping release not matching range constraints (%s): %s", upstream.Constraints, version.parsed.String())
 			continue
 		}
-		log.Debugf("Found latest matching tag: %s", tag)
-		return tag, nil
+		log.Debugf("Found latest matching tag: %s", version.orig)
+		return version.orig, nil
 	}
 
 	return "", errors.Errorf("no potential tag found")

--- a/upstream/github_test.go
+++ b/upstream/github_test.go
@@ -82,7 +82,7 @@ func TestNonExistentBranch(t *testing.T) {
 func TestBranchHappyPath(t *testing.T) {
 	gh := Github{
 		URL:    "helm/helm",
-		Branch: "master",
+		Branch: "main",
 	}
 
 	latestVersion, err := gh.LatestVersion()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes three issues in the container upstream:
1. Non-semver tags break instead of skipping
2. Returned value should be the original tag (e.g. v1.0.0) and not the "clean" tag (e.g. 1.0.0)
3. Sorting should use semvers instead of tags, existing impl results in 1.9.0 > 1.11.0

#### Does this PR introduce a user-facing change?

NONE
