### PR TITLE
Do not panic on regex compilation failure

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -154,7 +154,10 @@ func (c *Client) LocalCheck(dependencyFilePath, basePath string) error {
 			}
 
 			match := refPath.Match
-			matcher := regexp.MustCompile(match)
+			matcher, err := regexp.Compile(match)
+			if err != nil {
+				return errors.Wrap(err, "compiling regex")
+			}
 			scanner := bufio.NewScanner(file)
 
 			var found bool

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -115,6 +115,14 @@ func TestLocalOutOfSync(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestLocalInvalid(t *testing.T) {
+	client := NewClient()
+
+	err := client.LocalCheck("../testdata/local-invalid.yaml", "../testdata")
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "compiling regex")
+}
+
 func TestFileDoesntExist(t *testing.T) {
 	client := NewClient()
 

--- a/testdata/local-invalid.yaml
+++ b/testdata/local-invalid.yaml
@@ -1,0 +1,6 @@
+dependencies:
+- name: terraform
+  version: 0.10.0
+  refPaths:
+  - path: Dockerfile
+    match: (


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This fixes a panic if the provided `match` regex is invalid and returns
a proper error.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed panic if `match` regex does not compile.
```
