### PR TITLE
Add warning for archived GitHub and GitLab repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ test-docker: ## Runs unit testing in Docker
 	docker build -f Dockerfile-tests -t zeitgeist-tests .
 	docker run --rm --entrypoint cat zeitgeist-tests coverage.out > coverage.out
 
+generate: ## Generate go code for the fake clients
+	go generate ./...
+
 verify: verify-boilerplate verify-golangci-lint verify-go-mod  ## Runs verification scripts to ensure correct execution
 
 verify-boilerplate: ## Runs the file header check

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/xanzy/go-gitlab v0.51.1
+	github.com/xanzy/go-gitlab v0.52.2
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.7.1
 	sigs.k8s.io/release-sdk v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
-github.com/xanzy/go-gitlab v0.51.1 h1:wWKLalwx4omxFoHh3PLs9zDgAD4GXDP/uoxwMRCSiWM=
-github.com/xanzy/go-gitlab v0.51.1/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
+github.com/xanzy/go-gitlab v0.52.2 h1:gkgg1z4ON70sphibtD86Bfmt1qV3mZ0pU0CBBCFAEvQ=
+github.com/xanzy/go-gitlab v0.52.2/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/gitlab/gitlab_test.go
+++ b/pkg/gitlab/gitlab_test.go
@@ -174,3 +174,44 @@ func TestReleasesSuccessNoPreReleases(t *testing.T) {
 	require.Equal(t, tag2, res[1].TagName)
 	require.Equal(t, tag3, res[2].TagName)
 }
+
+func TestListProjects(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+	client.ListProjectsReturns([]*gogitlab.Project{
+		{ID: 1, Name: "honk"},
+	}, nil, nil)
+
+	// When
+	res, err := sut.GetRepository("honkcorp", "honk")
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, "honk", res.Name)
+}
+
+func TestListProjectsNoProjects(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+	client.ListProjectsReturns([]*gogitlab.Project{}, nil, nil)
+
+	// When
+	_, err := sut.GetRepository("honkcorp", "honk")
+	// Then
+	require.Error(t, err)
+	require.EqualError(t, err, "no project found")
+}
+
+func TestListProjectsMoreProjects(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+	client.ListProjectsReturns([]*gogitlab.Project{
+		{ID: 1, Name: "honk"},
+		{ID: 3, Name: "honk"},
+	}, nil, nil)
+
+	// When
+	_, err := sut.GetRepository("honkcorp", "honk")
+	// Then
+	require.Error(t, err)
+	require.EqualError(t, err, "expected one project got 2")
+}

--- a/pkg/gitlab/gitlabfakes/fake_client.go
+++ b/pkg/gitlab/gitlabfakes/fake_client.go
@@ -26,6 +26,21 @@ type FakeClient struct {
 		result2 *gitlaba.Response
 		result3 error
 	}
+	ListProjectsStub        func(*gitlaba.ListProjectsOptions) ([]*gitlaba.Project, *gitlaba.Response, error)
+	listProjectsMutex       sync.RWMutex
+	listProjectsArgsForCall []struct {
+		arg1 *gitlaba.ListProjectsOptions
+	}
+	listProjectsReturns struct {
+		result1 []*gitlaba.Project
+		result2 *gitlaba.Response
+		result3 error
+	}
+	listProjectsReturnsOnCall map[int]struct {
+		result1 []*gitlaba.Project
+		result2 *gitlaba.Response
+		result3 error
+	}
 	ListReleasesStub        func(string, string, *gitlaba.ListReleasesOptions) ([]*gitlaba.Release, *gitlaba.Response, error)
 	listReleasesMutex       sync.RWMutex
 	listReleasesArgsForCall []struct {
@@ -116,6 +131,73 @@ func (fake *FakeClient) ListBranchesReturnsOnCall(i int, result1 []*gitlaba.Bran
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) ListProjects(arg1 *gitlaba.ListProjectsOptions) ([]*gitlaba.Project, *gitlaba.Response, error) {
+	fake.listProjectsMutex.Lock()
+	ret, specificReturn := fake.listProjectsReturnsOnCall[len(fake.listProjectsArgsForCall)]
+	fake.listProjectsArgsForCall = append(fake.listProjectsArgsForCall, struct {
+		arg1 *gitlaba.ListProjectsOptions
+	}{arg1})
+	stub := fake.ListProjectsStub
+	fakeReturns := fake.listProjectsReturns
+	fake.recordInvocation("ListProjects", []interface{}{arg1})
+	fake.listProjectsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListProjectsCallCount() int {
+	fake.listProjectsMutex.RLock()
+	defer fake.listProjectsMutex.RUnlock()
+	return len(fake.listProjectsArgsForCall)
+}
+
+func (fake *FakeClient) ListProjectsCalls(stub func(*gitlaba.ListProjectsOptions) ([]*gitlaba.Project, *gitlaba.Response, error)) {
+	fake.listProjectsMutex.Lock()
+	defer fake.listProjectsMutex.Unlock()
+	fake.ListProjectsStub = stub
+}
+
+func (fake *FakeClient) ListProjectsArgsForCall(i int) *gitlaba.ListProjectsOptions {
+	fake.listProjectsMutex.RLock()
+	defer fake.listProjectsMutex.RUnlock()
+	argsForCall := fake.listProjectsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) ListProjectsReturns(result1 []*gitlaba.Project, result2 *gitlaba.Response, result3 error) {
+	fake.listProjectsMutex.Lock()
+	defer fake.listProjectsMutex.Unlock()
+	fake.ListProjectsStub = nil
+	fake.listProjectsReturns = struct {
+		result1 []*gitlaba.Project
+		result2 *gitlaba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListProjectsReturnsOnCall(i int, result1 []*gitlaba.Project, result2 *gitlaba.Response, result3 error) {
+	fake.listProjectsMutex.Lock()
+	defer fake.listProjectsMutex.Unlock()
+	fake.ListProjectsStub = nil
+	if fake.listProjectsReturnsOnCall == nil {
+		fake.listProjectsReturnsOnCall = make(map[int]struct {
+			result1 []*gitlaba.Project
+			result2 *gitlaba.Response
+			result3 error
+		})
+	}
+	fake.listProjectsReturnsOnCall[i] = struct {
+		result1 []*gitlaba.Project
+		result2 *gitlaba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) ListReleases(arg1 string, arg2 string, arg3 *gitlaba.ListReleasesOptions) ([]*gitlaba.Release, *gitlaba.Response, error) {
 	fake.listReleasesMutex.Lock()
 	ret, specificReturn := fake.listReleasesReturnsOnCall[len(fake.listReleasesArgsForCall)]
@@ -190,6 +272,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.listBranchesMutex.RLock()
 	defer fake.listBranchesMutex.RUnlock()
+	fake.listProjectsMutex.RLock()
+	defer fake.listProjectsMutex.RUnlock()
 	fake.listReleasesMutex.RLock()
 	defer fake.listReleasesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/upstream/github.go
+++ b/upstream/github.go
@@ -88,6 +88,16 @@ func latestRelease(upstream Github) (string, error) {
 	owner := splitURL[0]
 	repo := splitURL[1]
 
+	log.Debugf("Retrieving repository information for %s/%s...", owner, repo)
+	repoInfo, err := client.GetRepository(owner, repo)
+	if err != nil {
+		return "", errors.Wrap(err, "retrieving GitHub repository")
+	}
+
+	if repoInfo.GetArchived() {
+		log.Warnf("GitHub repository %s/%s is archived", owner, repo)
+	}
+
 	// We'll need to fetch all releases, as Github doesn't provide sorting options.
 	// If we don't do that, we risk running into the case where for example:
 	// - Version 1.0.0 and 2.0.0 exist

--- a/upstream/gitlab.go
+++ b/upstream/gitlab.go
@@ -148,6 +148,16 @@ func latestGitlabCommit(upstream *GitLab) (string, error) {
 	owner := splitURL[0]
 	repo := strings.Join(splitURL[1:], "/")
 
+	log.Debugf("Retrieving repository information for %s/%s...", owner, repo)
+	repoInfo, err := client.GetRepository(owner, repo)
+	if err != nil {
+		return "", errors.Wrap(err, "retrieving GitLab repository")
+	}
+
+	if repoInfo.Archived {
+		log.Warnf("GitLab repository %s/%s is archived", owner, repo)
+	}
+
 	branches, err := client.Branches(owner, repo)
 	if err != nil {
 		return "", errors.Wrap(err, "retrieving GitLab branches")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- warning for archived repos for GitHub and GitLab

/assign @Pluies @justaugustus
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

Fixes: https://github.com/kubernetes-sigs/zeitgeist/issues/48

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
warning for archived repos for GitHub and GitLab
```
