### PR TITLE
OWNERS: Reflect current Release Engineering roster

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,10 @@
 
 approvers:
   - sig-release-leads
+  - release-engineering-approvers
   - zeitgeist-approvers
 reviewers:
-  - zeitgeist-approvers
+  - release-engineering-reviewers
   - zeitgeist-reviewers
 labels:
   - sig/release

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,21 +2,33 @@
 
 aliases:
   sig-release-leads:
-    - alejandrox1
-    - justaugustus
-    - saschagrunert
-    - tpepper
+    - cpanato # SIG Technical Lead
+    - jeremyrickard # SIG Technical Lead
+    - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
+    - saschagrunert # SIG Chair
+  release-engineering-approvers:
+    - cpanato # Release Manager
+    - puerco # Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - palnabarun # Release Manager
+    - Verolop # Release Manager
+    - xmudrii # Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - mkorbi # Release Manager Associate
+    - onlydole # Release Manager Associate
+    - sethmccombs # Release Manager Associate
+    - thejoycekung # Release Manager Associate
+    - wilsonehusin # Release Manager Associate
   zeitgeist-approvers:
-    - alejandrox1 # subproject owner
     - justaugustus # subproject owner / Release Manager
     - Pluies # subproject owner
     - saschagrunert # subproject owner / Release Manager
-    - tpepper # subproject owner / Release Manager
   zeitgeist-reviewers:
-    - cpanato # Release Manager
-    - hasheddan # Release Manager
     - n3wscott
-    - saschagrunert # Release Manager
   
   # TODO: This alias, along with the buoy subdirectory, can be safely removed
   #       once buoy has been integrated with zeitgeist.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

OWNERS are pretty out-of-date.
Updated to roughly reflect what's in https://github.com/kubernetes/release/pull/2331 and https://kubernetes.io/releases/release-managers/.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco 
/cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
