### PR TITLE
list tags when there are no releases available

### DIFF
--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -55,6 +55,9 @@ type Client interface {
 	ListBranches(
 		string, string, *gitlab.ListBranchesOptions,
 	) ([]*gitlab.Branch, *gitlab.Response, error)
+	ListTags(
+		string, string, *gitlab.ListTagsOptions,
+	) ([]*gitlab.Tag, *gitlab.Response, error)
 }
 
 // New creates a new default GitLab client. Tokens set via the $GITLAB_TOKEN
@@ -122,6 +125,13 @@ func (g *gitlabClient) ListProjects(opt *gitlab.ListProjectsOptions,
 	return projects, resp, err
 }
 
+func (g *gitlabClient) ListTags(owner, repo string, opt *gitlab.ListTagsOptions,
+) ([]*gitlab.Tag, *gitlab.Response, error) {
+	project := fmt.Sprintf("%s/%s", owner, repo)
+	tags, resp, err := g.Tags.ListTags(project, opt)
+	return tags, resp, err
+}
+
 // SetClient can be used to manually set the internal GitLab client
 func (g *GitLab) SetClient(client Client) {
 	g.client = client
@@ -174,4 +184,17 @@ func (g *GitLab) GetRepository(owner, repo string) (*gitlab.Project, error) {
 	}
 
 	return projects[0], nil
+}
+
+// ListTags returns a list of GitLab tags for the provided `owner` and
+// `repo`.
+func (g *GitLab) ListTags(owner, repo string) ([]*gitlab.Tag, error) {
+	opt := &gitlab.ListTagsOptions{}
+
+	tags, _, err := g.client.ListTags(owner, repo, opt)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to retrieve GitLab tags for %s/%s", owner, repo)
+	}
+
+	return tags, nil
 }

--- a/pkg/gitlab/gitlab_test.go
+++ b/pkg/gitlab/gitlab_test.go
@@ -215,3 +215,28 @@ func TestListProjectsMoreProjects(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "expected one project got 2")
 }
+
+func TestListTags(t *testing.T) {
+	// Given
+	var (
+		tag1 = "v1.18.0"
+		tag2 = "v1.17.0"
+		tag3 = "v1.16.0"
+	)
+	sut, client := newSUT()
+	client.ListTagsReturns([]*gogitlab.Tag{
+		{Name: tag1},
+		{Name: tag2},
+		{Name: tag3},
+	}, nil, nil)
+
+	// When
+	res, err := sut.ListTags("", "")
+
+	// Then
+	require.Nil(t, err)
+	require.Len(t, res, 3)
+	require.Equal(t, tag1, res[0].Name)
+	require.Equal(t, tag2, res[1].Name)
+	require.Equal(t, tag3, res[2].Name)
+}

--- a/pkg/gitlab/gitlabfakes/fake_client.go
+++ b/pkg/gitlab/gitlabfakes/fake_client.go
@@ -58,6 +58,23 @@ type FakeClient struct {
 		result2 *gitlaba.Response
 		result3 error
 	}
+	ListTagsStub        func(string, string, *gitlaba.ListTagsOptions) ([]*gitlaba.Tag, *gitlaba.Response, error)
+	listTagsMutex       sync.RWMutex
+	listTagsArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *gitlaba.ListTagsOptions
+	}
+	listTagsReturns struct {
+		result1 []*gitlaba.Tag
+		result2 *gitlaba.Response
+		result3 error
+	}
+	listTagsReturnsOnCall map[int]struct {
+		result1 []*gitlaba.Tag
+		result2 *gitlaba.Response
+		result3 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -267,6 +284,75 @@ func (fake *FakeClient) ListReleasesReturnsOnCall(i int, result1 []*gitlaba.Rele
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) ListTags(arg1 string, arg2 string, arg3 *gitlaba.ListTagsOptions) ([]*gitlaba.Tag, *gitlaba.Response, error) {
+	fake.listTagsMutex.Lock()
+	ret, specificReturn := fake.listTagsReturnsOnCall[len(fake.listTagsArgsForCall)]
+	fake.listTagsArgsForCall = append(fake.listTagsArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *gitlaba.ListTagsOptions
+	}{arg1, arg2, arg3})
+	stub := fake.ListTagsStub
+	fakeReturns := fake.listTagsReturns
+	fake.recordInvocation("ListTags", []interface{}{arg1, arg2, arg3})
+	fake.listTagsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListTagsCallCount() int {
+	fake.listTagsMutex.RLock()
+	defer fake.listTagsMutex.RUnlock()
+	return len(fake.listTagsArgsForCall)
+}
+
+func (fake *FakeClient) ListTagsCalls(stub func(string, string, *gitlaba.ListTagsOptions) ([]*gitlaba.Tag, *gitlaba.Response, error)) {
+	fake.listTagsMutex.Lock()
+	defer fake.listTagsMutex.Unlock()
+	fake.ListTagsStub = stub
+}
+
+func (fake *FakeClient) ListTagsArgsForCall(i int) (string, string, *gitlaba.ListTagsOptions) {
+	fake.listTagsMutex.RLock()
+	defer fake.listTagsMutex.RUnlock()
+	argsForCall := fake.listTagsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) ListTagsReturns(result1 []*gitlaba.Tag, result2 *gitlaba.Response, result3 error) {
+	fake.listTagsMutex.Lock()
+	defer fake.listTagsMutex.Unlock()
+	fake.ListTagsStub = nil
+	fake.listTagsReturns = struct {
+		result1 []*gitlaba.Tag
+		result2 *gitlaba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListTagsReturnsOnCall(i int, result1 []*gitlaba.Tag, result2 *gitlaba.Response, result3 error) {
+	fake.listTagsMutex.Lock()
+	defer fake.listTagsMutex.Unlock()
+	fake.ListTagsStub = nil
+	if fake.listTagsReturnsOnCall == nil {
+		fake.listTagsReturnsOnCall = make(map[int]struct {
+			result1 []*gitlaba.Tag
+			result2 *gitlaba.Response
+			result3 error
+		})
+	}
+	fake.listTagsReturnsOnCall[i] = struct {
+		result1 []*gitlaba.Tag
+		result2 *gitlaba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -276,6 +362,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listProjectsMutex.RUnlock()
 	fake.listReleasesMutex.RLock()
 	defer fake.listReleasesMutex.RUnlock()
+	fake.listTagsMutex.RLock()
+	defer fake.listTagsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- list tags when there are no releases available

/assign @saschagrunert @Pluies @puerco @justaugustus 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:

Fixes #61 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
list tags when there are no releases available
```
