### PR TITLE
Skip pre-releases from helm upstreams

### DIFF
--- a/testdata/helm-repo/index.yaml
+++ b/testdata/helm-repo/index.yaml
@@ -77,4 +77,45 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/zeitgeist/releases/download/dependency-two-1.5.0/dependency-two-1.5.0.tgz
     version: 1.5.0
+  dependency-three:
+  - apiVersion: v2
+    appVersion: "1.0"
+    annotations:
+      artifacthub.io/prerelease: "true"
+    created: "2021-01-01T00:00:00Z"
+    description: A Helm chart for Kubernetes
+    digest: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    name: dependency-three
+    urls:
+    - https://github.com/kubernetes-sigs/zeitgeist/releases/download/dependency-three-invalid_semver-pre/dependency-three-invalid_semver-pre.tgz
+    version: invalid_semver-pre
+  - apiVersion: v2
+    appVersion: "1.0"
+    annotations:
+      artifacthub.io/prerelease: "true"
+    created: "2021-01-01T00:00:00Z"
+    description: A Helm chart for Kubernetes
+    digest: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    name: dependency-three
+    urls:
+    - https://github.com/kubernetes-sigs/zeitgeist/releases/download/dependency-three-0.2.0-beta.0/dependency-three-0.2.0-beta.0.tgz
+    version: 0.2.0-beta.0
+  - apiVersion: v2
+    appVersion: "1.0"
+    created: "2021-01-01T00:00:00Z"
+    description: A Helm chart for Kubernetes
+    digest: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    name: dependency-three
+    urls:
+    - https://github.com/kubernetes-sigs/zeitgeist/releases/download/dependency-three-0.2.0-alpha.0/dependency-three-0.2.0-alpha.0.tgz
+    version: 0.2.0-alpha.0
+  - apiVersion: v2
+    appVersion: "1.0"
+    created: "2021-01-01T00:00:00Z"
+    description: A Helm chart for Kubernetes
+    digest: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    name: dependency-three
+    urls:
+    - https://github.com/kubernetes-sigs/zeitgeist/releases/download/dependency-three-0.1.0/dependency-three-0.1.0.tgz
+    version: 0.1.0
 generated: "2021-01-01T00:00:00Z"

--- a/upstream/helm_test.go
+++ b/upstream/helm_test.go
@@ -214,3 +214,18 @@ func TestHelmHappyPathWithConstraintLocal(t *testing.T) {
 	require.NotEmpty(t, latestVersion)
 	require.Equal(t, latestVersion, "0.1.2")
 }
+
+func TestHelmHappyPathWithPrelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(helmHandler))
+	defer server.Close()
+
+	h := Helm{
+		Repo:  server.URL,
+		Chart: "dependency-three",
+	}
+
+	latestVersion, err := h.LatestVersion()
+	require.NoError(t, err)
+	require.NotEmpty(t, latestVersion)
+	require.Equal(t, latestVersion, "0.1.0")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The Github upstream already ignores pre-releases, but the helm one doesn't. This adds two simple checks to skip most pre-release charts. One is to check whether there is a `artifacthub.io/prerelease: "true"` annotation on the chart version, the other uses semver parsing on the chart version to determine whether it has pre-release components in the version string.

This won't catch non-semver pre-releases that don't have the annotation, but I'd hazard a guess that most charts will be covered. I can add other qualifiers if necessary, I just couldn't find a standardized way to handle this.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

I'm not sure whether this qualifies, but it would impact users who are already using pre-release charts.

```release-note
Disqualify pre-release helm charts from update checks
```