### PR TITLE
fix RemoteExport() returning already up-to-date dependencies

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -269,11 +269,12 @@ func (c *Client) RemoteExport(dependencyFilePath string) ([]VersionUpdate, error
 				NewVersion: vui.latest.Version,
 			})
 		} else {
-			versionUpdates = append(versionUpdates, VersionUpdate{
-				Name:       vui.name,
-				Version:    vui.current.Version,
-				NewVersion: vui.current.Version,
-			})
+			log.Debugf(
+				"No update available for dependency %s: %s (latest: %s)\n",
+				vui.name,
+				vui.current.Version,
+				vui.latest.Version,
+			)
 		}
 	}
 	return versionUpdates, nil

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -74,10 +74,7 @@ func TestDummyRemoteExportWithoutUpdate(t *testing.T) {
 
 	updates, err := client.RemoteExport("../testdata/remote-dummy.yaml")
 	require.Nil(t, err)
-	require.NotEmpty(t, updates)
-	require.Equal(t, updates[0].Name, "example")
-	require.Equal(t, updates[0].Version, "1.0.0")
-	require.Equal(t, updates[0].NewVersion, "1.0.0")
+	require.Empty(t, updates)
 }
 
 func TestDummyRemoteExportWithUpdate(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes the logic of [RemoteExport()](https://github.com/kubernetes-sigs/zeitgeist/blob/master/dependency/dependency.go#L251), so it does not return up-to-date dependencies.

#### Which issue(s) this PR fixes:

Fixes #169 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix RemoteExport() method to only return dependencies with updates.
```
