### PR TITLE
Fix local checks logic

### DIFF
--- a/commands/validate.go
+++ b/commands/validate.go
@@ -48,11 +48,11 @@ func addValidate(topLevel *cobra.Command) {
 func runValidate(opts *options) error {
 	client := dependency.NewClient()
 
-	if opts.localOnly {
-		if err := client.LocalCheck(opts.configFile, opts.basePath); err != nil {
-			return fmt.Errorf("checking local dependencies: %w", err)
-		}
-	} else {
+	if err := client.LocalCheck(opts.configFile, opts.basePath); err != nil {
+		return fmt.Errorf("checking local dependencies: %w", err)
+	}
+
+	if !opts.localOnly {
 		updates, err := client.RemoteCheck(opts.configFile)
 		if err != nil {
 			return fmt.Errorf("checking remote dependencies: %w", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

I recently noticed that db0fa72, by switching the logic around
local/remote checking, inadvertently made zeitgeist bypass local checks
by default (!).

This is a pretty major bug, as we lose half of the functionality
promised in the README (ensuring consistencies are kept up-to-date
within a project).

This commit fixes the logic to:
- Always run local checks
- Run remote checks, unless the --local-only flag is passed

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix local checking bypass issue
```
