### PR TITLE
Fix release code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
     - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
       with:
-        go-version: 1.17.x
+        go-version: 1.19.x
 
     - name: Install ko
-      uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
+      uses: imjasonh/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
 
     - name: Install cosign
       uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.1.0


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Github action to automatically release new versions of Zeitgeist is broken I believe, see recent runs: https://github.com/kubernetes-sigs/zeitgeist/actions/workflows/release.yml

This hopefully should fix it – I can't test it all locally unfortunately, as it uses secrets to log into the docker repository & push the image.
 
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
