### PR TITLE
Default name_template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,7 +44,6 @@ builds:
 
 archives:
 - format: binary
-  name_template: "{{ .Binary }}"
   allow_different_binary_count: true
 
 signs:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Remove the `name_template` customisation.

We're making good progress on the release action (woo!), but it's now failing when uploading the binaries:
```
      • uploading to release                         file=/home/runner/work/zeitgeist/zeitgeist/src/github.com/kubernetes-sigs/zeitgeist/dist/zeitgeist_linux_arm_7/zeitgeist name=zeitgeist
      • failed to upload artifact, will retry        artifact=zeitgeist error=POST https://uploads.github.com/repos/kubernetes-sigs/zeitgeist/releases/79032136/assets?name=zeitgeist: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}] try=3
      • uploading to release                         file=/home/runner/work/zeitgeist/zeitgeist/src/github.com/kubernetes-sigs/zeitgeist/dist/zeitgeist_windows_amd64_v1/zeitgeist.exe name=zeitgeist.exe
      • failed to upload artifact, will retry        artifact=zeitgeist error=POST https://uploads.github.com/repos/kubernetes-sigs/zeitgeist/releases/79032136/assets?name=zeitgeist: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}] try=2
```

I think the root cause is that we override the name_template for binaries to only include the binary names, which creates a `zeitgeist` binary for linux armv7, a `zeitgeist` binary for linux amd64, a `zeitgeist` binary for linux ppc64 etc etc, and Github isn;t happy when we try to upload all these identically-named assets to the same release.

I removed our name_template customisation, which will return to the default of `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}` as per [the docs](https://goreleaser.com/customization/archive/).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
