### PR TITLE
update cloudbuild and ko config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ bin/
 .idea
 /zeitgeist
 /imagerefs
+/imagerefs_buoy
 .vscode/*

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,5 @@
 ---
-defaultBaseImage: cgr.dev/chainguard/static:latest
+defaultBaseImage: gcr.io/distroless/static-debian11
 
 builds:
   - id: zeitgeist
@@ -9,25 +9,17 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
-      - -tags
-      - nostackdriver
     ldflags:
-      - -s
-      - -w
       - -extldflags "-static"
       - "{{ .Env.LDFLAGS }}"
 
   - id: buoy
-    dir: .
-    main: ./buoy
+    dir: ./buoy
+    main: .
     env:
       - CGO_ENABLED=0
     flags:
       - -trimpath
-      - -tags
-      - nostackdriver
     ldflags:
-      - -s
-      - -w
       - -extldflags "-static"
       - "{{ .Env.LDFLAGS }}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 timeout: 7200s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'N1_HIGHCPU_32'
 steps:
   - name: gcr.io/cloud-builders/git
     dir: "go/src/sigs.k8s.io"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Post submit cloudbuild job is failing due out of memory most likely, reproduced locally and got the same error, but when increasing the memory it build ok

bump the machine size and other changes for ko build
if does not work i will follow up again


/assign @saschagrunert @xmudrii @puerco 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
