### PR TITLE
update deprecated goreleaser flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ko-local: ## Build zeitgeist/buoy image locally (does not push it)
 .PHONY: snapshot
 snapshot: ## Build zeitgeist binaries with goreleaser in snapshot mode
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	goreleaser release --rm-dist --snapshot --skip-sign --skip-publish
+	goreleaser release --clean --snapshot --skip-sign --skip-publish
 
 lint:
 	test -z $(shell go fmt .) || (echo "Linting failed !" && exit 8)
@@ -91,7 +91,7 @@ verify-golangci-lint: ## Runs all golang linters
 .PHONY: goreleaser
 goreleaser: ## Build zeitgeist binaries with goreleaser
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	goreleaser release --rm-dist
+	goreleaser release --clean
 
 .PHONY: ko-release
 ko-release: ko-release-zeitgeist ko-release-buoy


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:

- update deprecated goreleaser flags

/assign @saschagrunert @xmudrii @puerco @ameukam 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
