### PR TITLE
Update golangci-lint to v1.53

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       - "release-note-none"
       - "ok-to-test"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+    open-pull-requests-limit: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: '1.20'
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:
-          version: v1.51.2
+          version: v1.53

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 1
           path: ./src/github.com/${{ github.repository }}
 
-      - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: '1.20'
           check-latest: true

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out code onto GOPATH
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: '1.20'
           check-latest: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - containedctx
     - contextcheck
     - decorder
-    - depguard
     - dogsled
     - dupl
     - durationcheck
@@ -183,7 +182,6 @@ linters-settings:
       - hexLiteral
       - httpNoBody
       - ifElseChain
-      - ioutilDeprecated
       - methodExprCall
       - newDeref
       - octalLiteral
@@ -199,7 +197,6 @@ linters-settings:
       - switchTrue
       - timeCmpSimplify
       - timeExprSimplify
-      - todoCommentWithoutDetail
       - tooManyResultsChecker
       - typeAssertChain
       - typeDefFirst

--- a/commands/export.go
+++ b/commands/export.go
@@ -79,10 +79,7 @@ func addExport(topLevel *cobra.Command) {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE: func(*cobra.Command, []string) error {
-			if err := exo.setAndValidate(); err != nil {
-				return err
-			}
-			return nil
+			return exo.setAndValidate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runExport(exo)

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -32,7 +32,7 @@ type mockedReceiveMsgs struct {
 	Resp ec2.DescribeImagesOutput
 }
 
-func (m mockedReceiveMsgs) DescribeImages(in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+func (m mockedReceiveMsgs) DescribeImages(_ *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
 	// Only need to return mocked response output
 	return &m.Resp, nil
 }

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERSION=v1.49.0
+VERSION=v1.53.3
 URL_BASE=https://raw.githubusercontent.com/golangci/golangci-lint
 URL=$URL_BASE/$VERSION/install.sh
 

--- a/upstream/ami_test.go
+++ b/upstream/ami_test.go
@@ -31,7 +31,7 @@ type mockedReceiveMsgs struct {
 	Resp ec2.DescribeImagesOutput
 }
 
-func (m mockedReceiveMsgs) DescribeImages(in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+func (m mockedReceiveMsgs) DescribeImages(_ *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
 	// Only need to return mocked response output
 	return &m.Resp, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- enable dependabot for github-actions
- update golangci-lint to v1.53
- update golangci-lint config and fix lints

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
