### PR TITLE
Fix unordered releases bug

### DIFF
--- a/upstream/github.go
+++ b/upstream/github.go
@@ -17,7 +17,6 @@ limitations under the License.
 package upstream
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -137,26 +136,7 @@ func latestRelease(upstream Github) (string, error) {
 		}
 	}
 
-	return selectHighestVersion(upstream, expectedRange, tags)
-}
-
-func selectHighestVersion(upstream Github, expectedRange semver.Range, tags []string) (string, error) {
-	for _, tag := range tags {
-		// Try to match semver and range
-		version, err := semver.Parse(strings.Trim(tag, "v"))
-		if err != nil {
-			log.Debugf("Error parsing version %s (%#v) as semver, cannot validate semver constraints", tag, err)
-		} else if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%s): %s\n", upstream.Constraints, tag)
-			continue
-		}
-
-		log.Debugf("Found latest matching release: %s\n", version.String())
-		return version.String(), nil
-	}
-
-	// No latest version found – no versions? Only prereleases?
-	return "", errors.New("no potential version found")
+	return selectHighestVersion(upstream.Constraints, expectedRange, tags)
 }
 
 func latestCommit(upstream Github) (string, error) {

--- a/upstream/github.go
+++ b/upstream/github.go
@@ -137,6 +137,10 @@ func latestRelease(upstream Github) (string, error) {
 		}
 	}
 
+	return selectHighestVersion(upstream, expectedRange, tags)
+}
+
+func selectHighestVersion(upstream Github, expectedRange semver.Range, tags []string) (string, error) {
 	for _, tag := range tags {
 		// Try to match semver and range
 		version, err := semver.Parse(strings.Trim(tag, "v"))

--- a/upstream/github_test.go
+++ b/upstream/github_test.go
@@ -19,6 +19,7 @@ package upstream
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/require"
 
 	"gopkg.in/yaml.v3"
@@ -103,4 +104,20 @@ func TestHappyPath(t *testing.T) {
 	latestVersion, err := gh.LatestVersion()
 	require.NoError(t, err)
 	require.NotEmpty(t, latestVersion)
+}
+
+func TestSelectHighestVersion(t *testing.T) {
+	gh := Github{
+		URL: "helm/helm",
+	}
+	expectedRange, err := semver.ParseRange(DefaultSemVerConstraints)
+	require.NoError(t, err)
+	tags := []string{
+		"v1.31.4",
+		"v1.29.2",
+		"v1.32.2",
+	}
+	v, err := selectHighestVersion(gh, expectedRange, tags)
+	require.NoError(t, err)
+	require.Equal(t, "v1.32.2", v)
 }

--- a/upstream/github_test.go
+++ b/upstream/github_test.go
@@ -106,18 +106,52 @@ func TestHappyPath(t *testing.T) {
 	require.NotEmpty(t, latestVersion)
 }
 
-func TestSelectHighestVersion(t *testing.T) {
+func TestSelectHighestVersionOrdered(t *testing.T) {
 	gh := Github{
 		URL: "helm/helm",
 	}
 	expectedRange, err := semver.ParseRange(DefaultSemVerConstraints)
 	require.NoError(t, err)
 	tags := []string{
+		"v1.32.2",
+		"v1.31.4",
+		"v1.29.2",
+	}
+	v, err := selectHighestVersion(gh.Constraints, expectedRange, tags)
+	require.NoError(t, err)
+	require.Equal(t, "v1.32.2", v)
+}
+
+func TestSelectHighestVersionOrderedWithConstraints(t *testing.T) {
+	gh := Github{
+		URL:         "helm/helm",
+		Constraints: "<1.30.0",
+	}
+	expectedRange, err := semver.ParseRange(gh.Constraints)
+	require.NoError(t, err)
+	tags := []string{
+		"v1.32.2",
+		"v1.31.4",
+		"v1.29.2",
+	}
+	v, err := selectHighestVersion(gh.Constraints, expectedRange, tags)
+	require.NoError(t, err)
+	require.Equal(t, "v1.29.2", v)
+}
+
+func TestSelectHighestVersionUnorderedWithConstraints(t *testing.T) {
+	gh := Github{
+		URL:         "helm/helm",
+		Constraints: "<1.30.0",
+	}
+	expectedRange, err := semver.ParseRange(gh.Constraints)
+	require.NoError(t, err)
+	tags := []string{
 		"v1.31.4",
 		"v1.29.2",
 		"v1.32.2",
 	}
-	v, err := selectHighestVersion(gh, expectedRange, tags)
+	v, err := selectHighestVersion(gh.Constraints, expectedRange, tags)
 	require.NoError(t, err)
-	require.Equal(t, "v1.32.2", v)
+	require.Equal(t, "v1.29.2", v)
 }

--- a/upstream/gitlab.go
+++ b/upstream/gitlab.go
@@ -128,23 +128,7 @@ func latestGitLabRelease(upstream *GitLab) (string, error) {
 		}
 	}
 
-	for _, tag := range tags {
-		// Try to match semver and range
-		version, err := semver.Parse(strings.Trim(tag, "v"))
-		if err != nil {
-			log.Debugf("Error parsing version %s (%#v) as semver, cannot validate semver constraints", tag, err)
-		} else if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%s): %s\n", upstream.Constraints, tag)
-			continue
-		}
-
-		log.Debugf("Found latest matching release: %s\n", version)
-
-		return version.String(), nil
-	}
-
-	// No latest version found – no versions? Only prereleases?
-	return "", errors.New("no potential version found")
+	return selectHighestVersion(upstream.Constraints, expectedRange, tags)
 }
 
 func latestGitlabCommit(upstream *GitLab) (string, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix incorrect latest version for github/gitlab upstreams

Extract the logic to get the latest version from a list of releases/tags and test it separately.

#### Which issue(s) this PR fixes:

Fixes #758

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix incorrect logic for latest version for github/gitlab upstreams when releases are unordered
```
