### PR TITLE
Fix incorrect latest version for github/gitlab upstreams

### DIFF
--- a/upstream/github.go
+++ b/upstream/github.go
@@ -17,7 +17,6 @@ limitations under the License.
 package upstream
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -137,22 +136,7 @@ func latestRelease(upstream Github) (string, error) {
 		}
 	}
 
-	for _, tag := range tags {
-		// Try to match semver and range
-		version, err := semver.Parse(strings.Trim(tag, "v"))
-		if err != nil {
-			log.Debugf("Error parsing version %s (%#v) as semver, cannot validate semver constraints", tag, err)
-		} else if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%s): %s\n", upstream.Constraints, tag)
-			continue
-		}
-
-		log.Debugf("Found latest matching release: %s\n", version.String())
-		return version.String(), nil
-	}
-
-	// No latest version found – no versions? Only prereleases?
-	return "", errors.New("no potential version found")
+	return selectHighestVersion(upstream.Constraints, expectedRange, tags)
 }
 
 func latestCommit(upstream Github) (string, error) {

--- a/upstream/gitlab.go
+++ b/upstream/gitlab.go
@@ -128,23 +128,7 @@ func latestGitLabRelease(upstream *GitLab) (string, error) {
 		}
 	}
 
-	for _, tag := range tags {
-		// Try to match semver and range
-		version, err := semver.Parse(strings.Trim(tag, "v"))
-		if err != nil {
-			log.Debugf("Error parsing version %s (%#v) as semver, cannot validate semver constraints", tag, err)
-		} else if !expectedRange(version) {
-			log.Debugf("Skipping release not matching range constraints (%s): %s\n", upstream.Constraints, tag)
-			continue
-		}
-
-		log.Debugf("Found latest matching release: %s\n", version)
-
-		return version.String(), nil
-	}
-
-	// No latest version found – no versions? Only prereleases?
-	return "", errors.New("no potential version found")
+	return selectHighestVersion(upstream.Constraints, expectedRange, tags)
 }
 
 func latestGitlabCommit(upstream *GitLab) (string, error) {

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -26,6 +26,10 @@ package upstream
 
 import (
 	"errors"
+
+	"github.com/blang/semver/v4"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/release-utils/util"
 )
 
 // Base only contains a flavour. "Concrete" upstreams each implement their own fields.
@@ -66,3 +70,35 @@ const (
 
 	DefaultSemVerConstraints = ">= 0.0.0"
 )
+
+func selectHighestVersion(constraints string, expectedRange semver.Range, tags []string) (string, error) {
+	var candidateVersion semver.Version
+	candidateVersionString := "" // keep the version string separately as it may contain a leading `v`
+	for _, tag := range tags {
+		// Try to match semver and range
+		version, err := util.TagStringToSemver(tag)
+		if err != nil {
+			log.Debugf("Error parsing version %s (%#v) as semver, cannot validate semver constraints", tag, err)
+			continue
+		}
+
+		if !expectedRange(version) {
+			log.Debugf("Skipping release not matching range constraints (%s): %s", constraints, tag)
+			continue
+		}
+
+		log.Debugf("Found potential release: %s\n", version.String())
+		if candidateVersionString == "" || version.GT(candidateVersion) {
+			log.Debugf("Release is the newest found so far: %s", version.String())
+			candidateVersion = version
+			candidateVersionString = tag
+		}
+	}
+
+	if candidateVersionString != "" {
+		return candidateVersionString, nil
+	}
+
+	// No latest version found – no versions? Only prereleases?
+	return "", errors.New("no potential version found")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix incorrect latest version for github/gitlab upstreams

Extract the logic to get the latest version from a list of releases/tags and test it separately.

#### Which issue(s) this PR fixes:

Fixes #758

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix incorrect logic for latest version for github/gitlab upstreams when releases are unordered
```