### PR TITLE
Preserve version number formatting during upgrade

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -529,6 +529,8 @@ func (c *Client) checkUpstreamVersions(deps []*Dependency) ([]versionUpdateInfo,
 			return nil, err
 		}
 
+		latestVersion.Version = formatVersion(currentVersion.Version, latestVersion.Version)
+
 		versionUpdates = append(versionUpdates, versionUpdateInfo{
 			name:            dep.Name,
 			current:         currentVersion,

--- a/dependency/version.go
+++ b/dependency/version.go
@@ -131,3 +131,16 @@ func semverCompare(a, b semver.Version, sensitivity VersionSensitivity) (bool, e
 		return false, fmt.Errorf("unknown version sensitivity: %s", sensitivity)
 	}
 }
+
+// formatVersion preserves the string formatting from the template and ensures the version
+// uses the same style (v-prefix).
+func formatVersion(template, version string) string {
+	// Use same prefix for both versions
+	if strings.HasPrefix(template, "v") {
+		if strings.HasPrefix(version, "v") {
+			return version
+		}
+		return "v" + version
+	}
+	return strings.TrimPrefix(version, "v")
+}

--- a/dependency/version_test.go
+++ b/dependency/version_test.go
@@ -142,3 +142,45 @@ func TestRandomVersions(t *testing.T) {
 	shouldBeFalse, _ := a.MoreRecentThan(a)
 	require.False(t, shouldBeFalse)
 }
+
+func TestFormatVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		version  string
+		want     string
+	}{
+		{
+			name:     "Both versions start with 'v'",
+			template: "v1.0.0",
+			version:  "v2.0.0",
+			want:     "v2.0.0",
+		},
+		{
+			name:     "Template starts with 'v', version does not",
+			template: "v1.0.0",
+			version:  "2.0.0",
+			want:     "v2.0.0",
+		},
+		{
+			name:     "Template does not start with 'v', version does",
+			template: "1.0.0",
+			version:  "v2.0.0",
+			want:     "2.0.0",
+		},
+		{
+			name:     "Neither version starts with 'v'",
+			template: "1.0.0",
+			version:  "2.0.0",
+			want:     "2.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatVersion(tt.template, tt.version); got != tt.want {
+				t.Errorf("formatVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If the dependencies.yaml file does not have v-prefix, the referenced
files would be updated to include duplicate v-prefix during upgrade.

This change ensures we preserve the style that is currently used,
instead of enforcing the same style as the upstream repo uses.

Typically, Github release tags have v-prefix, while other sources
like helm does not have any prefix. Since Github projects may have
v-prefix in the release tag bug not in the container image tag, it's
useful to support v-less versions in dependencies.yaml. It's already
supported by validate, but not upgrade.


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow zeitgeist upgrade without getting "vv1.0.0" in the result, and
allow tags like image:1.0.0 even if the upstream repo on github has
tag v1.0.0.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Preserve formatting of version numbers when using zeitgeist upgrade
```
