### PR TITLE
Add zeitgeist upgrade --base-path and upgrade unit tests

### DIFF
--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -53,7 +53,7 @@ func runUpgrade(opts *options) error {
 		return fmt.Errorf("checking local dependencies: %w", err)
 	}
 
-	updates, err := client.Upgrade(opts.configFile)
+	updates, err := client.Upgrade(opts.configFile, opts.basePath)
 	if err != nil {
 		return fmt.Errorf("upgrade dependencies: %w", err)
 	}

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -271,7 +271,7 @@ func (c *Client) RemoteCheck(dependencyFilePath string) ([]string, error) {
 //
 // Will return an error if checking the versions upstream fails, or if updating
 // files fails.
-func (c *Client) Upgrade(dependencyFilePath string) ([]string, error) {
+func (c *Client) Upgrade(dependencyFilePath, basePath string) ([]string, error) {
 	externalDeps, err := fromFile(dependencyFilePath)
 	if err != nil {
 		return nil, err
@@ -292,7 +292,7 @@ func (c *Client) Upgrade(dependencyFilePath string) ([]string, error) {
 		}
 
 		if vu.updateAvailable {
-			err = upgradeDependency(dependency, &vu)
+			err = upgradeDependency(basePath, dependency, &vu)
 			if err != nil {
 				return nil, err
 			}
@@ -347,10 +347,10 @@ func findDependencyByName(dependencies []*Dependency, name string) (*Dependency,
 	return nil, fmt.Errorf("cannot find dependency by name: %s", name)
 }
 
-func upgradeDependency(dependency *Dependency, versionUpdate *versionUpdateInfo) error {
+func upgradeDependency(basePath string, dependency *Dependency, versionUpdate *versionUpdateInfo) error {
 	log.Debugf("running upgradeDependency, versionUpdate %#v", versionUpdate)
 	for _, refPath := range dependency.RefPaths {
-		err := replaceInFile(refPath, versionUpdate)
+		err := replaceInFile(basePath, refPath, versionUpdate)
 		if err != nil {
 			return err
 		}
@@ -359,7 +359,8 @@ func upgradeDependency(dependency *Dependency, versionUpdate *versionUpdateInfo)
 	return nil
 }
 
-func replaceInFile(refPath *RefPath, versionUpdate *versionUpdateInfo) error {
+func replaceInFile(basePath string, refPath *RefPath, versionUpdate *versionUpdateInfo) error {
+	filename := filepath.Join(basePath, refPath.Path)
 	log.Debugf("running replaceInFile, refpath is %#v, versionUpdate %#v", refPath, versionUpdate)
 
 	matcher, err := regexp.Compile(refPath.Match)
@@ -367,7 +368,7 @@ func replaceInFile(refPath *RefPath, versionUpdate *versionUpdateInfo) error {
 		return fmt.Errorf("compiling regex: %w", err)
 	}
 
-	inputFile, err := os.ReadFile(refPath.Path)
+	inputFile, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
 	}
@@ -394,7 +395,7 @@ func replaceInFile(refPath *RefPath, versionUpdate *versionUpdateInfo) error {
 	upgradedFile := strings.Join(lines, "\n")
 
 	// Finally, write the file out
-	err = os.WriteFile(refPath.Path, []byte(upgradedFile), 0o644)
+	err = os.WriteFile(filename, []byte(upgradedFile), 0o644)
 
 	if err != nil {
 		return fmt.Errorf("writing file: %w", err)

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -439,6 +439,11 @@ func (c *Client) checkUpstreamVersions(deps []*Dependency) ([]versionUpdateInfo,
 	versionUpdates := []versionUpdateInfo{}
 	for _, dep := range deps {
 		if dep.Upstream == nil {
+			versionUpdates = append(versionUpdates, versionUpdateInfo{
+				name:            dep.Name,
+				current:         Version{dep.Version, dep.Scheme},
+				updateAvailable: false,
+			})
 			continue
 		}
 

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -182,6 +182,18 @@ func TestCheckUpstreamVersions(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:        "test-no-upstream",
+			Version:     "0.0.1",
+			Scheme:      Semver,
+			Sensitivity: Patch,
+			RefPaths: []*RefPath{
+				{
+					Path:  "test",
+					Match: "test",
+				},
+			},
+		},
 	}
 
 	client := NewClient()
@@ -200,6 +212,14 @@ func TestCheckUpstreamVersions(t *testing.T) {
 				Scheme:  Semver,
 			},
 			updateAvailable: true,
+		},
+		{
+			name: "test-no-upstream",
+			current: Version{
+				Version: "0.0.1",
+				Scheme:  Semver,
+			},
+			updateAvailable: false,
 		},
 	}
 
@@ -228,6 +248,12 @@ dependencies:
     refPaths:
     - path: test.txt
       match: VERSION
+  - name: no-upstream
+    version: 0.0.1
+    scheme: semver
+    refPaths:
+    - path: test.txt
+      match: OTHER
 `), 0o644)
 	require.Nil(t, err)
 


### PR DESCRIPTION
- Add --base-path support for zeitgeist upgrade, and unit tests for upgrade
- Preserve dependencies without upstreams during upgrade

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* zeitgeist upgrade did not support --base-path (unlike validate)
* no tests for upgrade
* upgrade would drop entries from dependencies.yaml if they do not have an upstream

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support --base-path in zeitgeist upgrade.
```
