### PR TITLE
Add set-version command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -75,6 +75,7 @@ func AddCommands(topLevel *cobra.Command) {
 	addValidate(topLevel)
 	addExport(topLevel)
 	addUpgrade(topLevel)
+	addSetVersion(topLevel)
 }
 
 func initLogging(*cobra.Command, []string) error {

--- a/commands/set_version.go
+++ b/commands/set_version.go
@@ -56,8 +56,8 @@ func runSetVersion(opts *options, args []string) error {
 		return fmt.Errorf("checking local dependencies: %w", err)
 	}
 
-	dependency, version := args[0], args[1]
-	if err := client.SetVersion(opts.configFile, opts.basePath, dependency, version); err != nil {
+	dependencyName, version := args[0], args[1]
+	if err := client.SetVersion(opts.configFile, opts.basePath, dependencyName, version); err != nil {
 		return fmt.Errorf("set dependency version: %w", err)
 	}
 

--- a/commands/set_version.go
+++ b/commands/set_version.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/zeitgeist/dependency"
+)
+
+func addSetVersion(topLevel *cobra.Command) {
+	vo := rootOpts
+
+	cmd := &cobra.Command{
+		Use:           "set-version <dependency> <version>",
+		Short:         "Set version of dependency based on given input",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE: func(*cobra.Command, []string) error {
+			return vo.setAndValidate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSetVersion(vo, args)
+		},
+	}
+
+	topLevel.AddCommand(cmd)
+}
+
+// runSetVersion is the function invoked by 'addSetVersion', responsible for
+// upgrading/downgrading a single dependency to the specified version.
+func runSetVersion(opts *options, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("expected exactly two arguments: <dependency> <version>")
+	}
+
+	client := dependency.NewClient()
+
+	// Check locally first: it's fast, and ensures we're working on clean files
+	if err := client.LocalCheck(opts.configFile, opts.basePath); err != nil {
+		return fmt.Errorf("checking local dependencies: %w", err)
+	}
+
+	dependency, version := args[0], args[1]
+	if err := client.SetVersion(opts.configFile, opts.basePath, dependency, version); err != nil {
+		return fmt.Errorf("set dependency version: %w", err)
+	}
+
+	return nil
+}

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -350,10 +350,6 @@ func (c *Client) SetVersion(dependencyFilePath, basePath, dependency, version st
 	found := false
 	for _, dep := range externalDeps.Dependencies {
 		if dep.Name == dependency {
-			if dep.Version == version {
-				return fmt.Errorf("version %s is already set for dependency %s", version, dependency)
-			}
-
 			found = true
 
 			if err := upgradeDependency(basePath, dep, &versionUpdateInfo{


### PR DESCRIPTION
set-version takes a single dependency and sets it to a specific version.

This could be used in a script or pipeline based on the output from zeitgeist export, or for manual upgrade/downgrade.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Updates #810

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The new command set-version can be used to upgrade a single dependency, for manual use or as part of a pipeline to automatically update dependencies.
```
