### PR TITLE
Enable and fix `perfsprint` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,7 @@ linters:
     - nilnil
     - nonamedreturns
     - nosprintfhostport
+    - perfsprint
     - prealloc
     - predeclared
     - promlinter

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -17,8 +17,6 @@ limitations under the License.
 package commands
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/release-utils/log"
@@ -67,7 +65,7 @@ func New(opts Options) *cobra.Command {
 		&rootOpts.logLevel,
 		"log-level",
 		"info",
-		fmt.Sprintf("the logging verbosity, either %s", log.LevelNames()),
+		"the logging verbosity, either "+log.LevelNames(),
 	)
 
 	AddCommands(cmd)

--- a/commands/export.go
+++ b/commands/export.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -57,7 +58,7 @@ func (exo *exportOptions) setAndValidate() error {
 	case JSON:
 	case LOG:
 	default:
-		return fmt.Errorf("unsuported output format")
+		return errors.New("unsuported output format")
 	}
 
 	if exo.outputFile != "" && OutputFormat(exo.outputFormat) == LOG {

--- a/commands/set_version.go
+++ b/commands/set_version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package commands
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ func addSetVersion(topLevel *cobra.Command) {
 // upgrading/downgrading a single dependency to the specified version.
 func runSetVersion(opts *options, args []string) error {
 	if len(args) != 2 {
-		return fmt.Errorf("expected exactly two arguments: <dependency> <version>")
+		return errors.New("expected exactly two arguments: <dependency> <version>")
 	}
 
 	client, err := dependency.NewLocalClient()

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gitlab
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -179,7 +180,7 @@ func (g *GitLab) GetRepository(owner, repo string) (*gitlab.Project, error) {
 	}
 
 	if len(projects) == 0 {
-		return nil, fmt.Errorf("no project found")
+		return nil, errors.New("no project found")
 	}
 
 	return projects[0], nil


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Enable the linter and fix the reports.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
