### PR TITLE
disabling go proxy for now, looks like we cannot build two different binaries, it build only the root one

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,8 +10,9 @@ before:
     - go mod tidy
     - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
 
-gomod:
-  proxy: true
+# disabling for now, looks like we cannot build two different binaries, it build only the root one.
+# gomod:
+#   proxy: true
 
 builds:
   - id: zeitgeist-remote


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

- disabling go proxy for now, looks like we cannot build two different binaries, it build only the root one

/assign @saschagrunert @xmudrii 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:



None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
