### PR TITLE
Use semver.parseTolerant

### DIFF
--- a/dependency/version.go
+++ b/dependency/version.go
@@ -94,13 +94,13 @@ func (a Version) MoreSensitivelyRecentThan(b Version, sensitivity VersionSensiti
 
 	switch a.Scheme {
 	case Semver:
-		aSemver, err := semver.Parse(strings.TrimPrefix(a.Version, "v"))
+		aSemver, err := semver.ParseTolerant(a.Version)
 		if err != nil {
 			log.Debugf("Failed to semver-parse %s", a.Version)
 			return false, err
 		}
 
-		bSemver, err := semver.Parse(strings.TrimPrefix(b.Version, "v"))
+		bSemver, err := semver.ParseTolerant(b.Version)
 		if err != nil {
 			log.Debugf("Failed to semver-parse %s", b.Version)
 			return false, err

--- a/remote/dependency/dependency.go
+++ b/remote/dependency/dependency.go
@@ -357,12 +357,12 @@ func (c *RemoteClient) CheckUpstreamVersions(deps []*deppkg.Dependency) ([]deppk
 		}
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("dependency %s: %w", dep.Name, err)
 		}
 
 		updateAvailable, err := latestVersion.MoreSensitivelyRecentThan(currentVersion, dep.Sensitivity)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("comparing dependency %s: %w", dep.Name, err)
 		}
 
 		versionUpdates = append(versionUpdates, deppkg.VersionUpdateInfo{

--- a/remote/dependency/dependency_test.go
+++ b/remote/dependency/dependency_test.go
@@ -169,6 +169,53 @@ func TestCheckUpstreamVersions(t *testing.T) {
 	}
 }
 
+func TestCheckUpstreamVersionsTolerant(t *testing.T) {
+	deps := []*deppkg.Dependency{
+		{
+			Name:        "test",
+			Version:     "0.0.1",
+			Scheme:      deppkg.Semver,
+			Sensitivity: deppkg.Patch,
+			Upstream: map[string]string{
+				"flavour": "dummy",
+				"latest":  "2.0",
+			},
+			RefPaths: []*deppkg.RefPath{
+				{
+					Path:  "test",
+					Match: "test",
+				},
+			},
+		},
+	}
+
+	client, err := NewRemoteClient()
+	require.NoError(t, err)
+	updateInfos, err := client.CheckUpstreamVersions(deps)
+	require.NoError(t, err)
+
+	expectedUpdateInfos := []deppkg.VersionUpdateInfo{
+		{
+			Name: "test",
+			Current: deppkg.Version{
+				Version: "0.0.1",
+				Scheme:  deppkg.Semver,
+			},
+			Latest: deppkg.Version{
+				Version: "2.0",
+				Scheme:  deppkg.Semver,
+			},
+			UpdateAvailable: true,
+		},
+	}
+
+	for i, updateInfo := range updateInfos {
+		if !reflect.DeepEqual(updateInfo, expectedUpdateInfos[i]) {
+			t.Errorf("checkUpstreamVersions mismatch at index %d:\ngot: %#v\nexpected: %#v", i, updateInfo, expectedUpdateInfos[i])
+		}
+	}
+}
+
 func TestUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	testFile := filepath.Join(dir, "test.txt")

--- a/upstream/dummy.go
+++ b/upstream/dummy.go
@@ -16,12 +16,16 @@ limitations under the License.
 
 package upstream
 
-// Dummy upstream needs no parameters and always returns a latest version of 1.0.0. Can be used for testing.
+// Dummy upstream always returns a fixed latest version, by default 1.0.0. Can be used for testing.
 type Dummy struct {
 	Base
+	Latest string
 }
 
-// LatestVersion always returns 1.0.0.
+// LatestVersion always returns a fixed version.
 func (upstream Dummy) LatestVersion() (string, error) {
+	if upstream.Latest != "" {
+		return upstream.Latest, nil
+	}
 	return "1.0.0", nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Use semver.ParseTolerant to check if the latest version is newer than the current version, matching the behaviour used to pick the latest version in the first place.

#### Which issue(s) this PR fixes:

Fixes #859 