### PR TITLE
Bump cloudbuild image to go1.23

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
         echo "Checking out ${_PULL_BASE_REF}"
         git checkout ${_PULL_BASE_REF}
 
-  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.22-bookworm'
+  - name: 'gcr.io/k8s-staging-releng/releng-ci:latest-go1.23-bookworm'
     dir: "go/src/sigs.k8s.io/zeitgeist"
     entrypoint: make
     env:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Update cloudbuild image to 1.23 to match the switch to go 1.23 in #1048

#### Which issue(s) this PR fixes:


Fixes failing builds on `master`, eg [this build](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-zeitgeist-push-images/1846796556187996160) on latest master commit c7750ab

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
