### PR TITLE
Tighten json parsing of dependencies.yaml

### DIFF
--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -77,6 +77,15 @@ func TestLocalInvalid(t *testing.T) {
 	require.Contains(t, err.Error(), "compiling regex")
 }
 
+func TestLocalTypo(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	err = client.LocalCheck("../testdata/local-typo.yaml", "../testdata")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected key: mathc")
+}
+
 func TestFileDoesntExist(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)

--- a/testdata/local-typo.yaml
+++ b/testdata/local-typo.yaml
@@ -1,0 +1,6 @@
+dependencies:
+- name: terraform
+  version: 0.10.0
+  refPaths:
+  - path: Dockerfile
+    mathc: misspelt-match-there-whoops


### PR DESCRIPTION
#### What this PR does / why we need it:

We currently silently ignore broken configuration, which is dangerous. Let's bubble up errors with configuration, especially:
- unexpected fields, indicating typos or other errors
- missing mandatory fields

#### Which issue(s) this PR fixes:

Fixes #1223 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix silent issues with misspelt keys
```
