### PR TITLE
Tighten json parsing of dependencies.yaml

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -141,8 +141,17 @@ func FromFile(dependencyFilePath string) (*Dependencies, error) {
 
 	dependencies := &Dependencies{}
 
-	err = yaml.Unmarshal(depFile, dependencies)
-	if err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(depFile))
+	decoder.KnownFields(true) // Disallow unknown fields
+	if err = decoder.Decode(dependencies); err != nil {
+		if err.Error() == "EOF" {
+			return nil, fmt.Errorf("can't decode YAML from configuration file '%s': %v", dependencyFilePath, err)
+		}
+		re := regexp.MustCompile(`field (.*) not found`)
+		matches := re.FindStringSubmatch(err.Error())
+		if len(matches) > 1 {
+			return nil, fmt.Errorf("unexpected key: %s", matches[1])
+		}
 		return nil, err
 	}
 
@@ -255,7 +264,7 @@ func (c *LocalClient) LocalCheck(dependencyFilePath, basePath string) error {
 //
 // Will return an error  if updating files fails.
 func (c *LocalClient) SetVersion(dependencyFilePath, basePath, dependency, version string) error {
-	externalDeps, err := fromFile(dependencyFilePath)
+	externalDeps, err := FromFile(dependencyFilePath)
 	if err != nil {
 		return err
 	}
@@ -289,7 +298,7 @@ func (c *LocalClient) SetVersion(dependencyFilePath, basePath, dependency, versi
 	}
 
 	// Update the dependencies file to reflect the upgrades
-	err = toFile(dependencyFilePath, externalDeps)
+	err = ToFile(dependencyFilePath, externalDeps)
 	if err != nil {
 		return err
 	}
@@ -369,39 +378,5 @@ func replaceInFile(basePath string, refPath *RefPath, versionUpdate *VersionUpda
 	if err != nil {
 		return fmt.Errorf("writing file: %w", err)
 	}
-	return nil
-}
-
-func fromFile(dependencyFilePath string) (*Dependencies, error) {
-	depFile, err := os.ReadFile(dependencyFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	dependencies := &Dependencies{}
-
-	err = yaml.Unmarshal(depFile, dependencies)
-	if err != nil {
-		return nil, err
-	}
-
-	return dependencies, nil
-}
-
-func toFile(dependencyFilePath string, dependencies *Dependencies) error {
-	var output bytes.Buffer
-	yamlEncoder := yaml.NewEncoder(&output)
-	yamlEncoder.SetIndent(2)
-
-	err := yamlEncoder.Encode(dependencies)
-	if err != nil {
-		return err
-	}
-
-	err = os.WriteFile(dependencyFilePath, output.Bytes(), 0o644)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -108,11 +108,11 @@ func (decoded *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) erro
 
 	// Custom validation for the Dependency type
 	if d.Name == "" {
-		return fmt.Errorf("Dependency has no `name`: %#v", d)
+		return fmt.Errorf("dependency has no `name`: %#v", d)
 	}
 
 	if d.Version == "" {
-		return fmt.Errorf("Dependency has no `version`: %#v", d)
+		return fmt.Errorf("dependency has no `version`: %#v", d)
 	}
 
 	// Default scheme to Semver if unset
@@ -120,12 +120,22 @@ func (decoded *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) erro
 		d.Scheme = Semver
 	}
 
-	// Validate Scheme and return
+	// Validate Scheme
 	switch d.Scheme {
 	case Semver, Alpha, Random:
 		// All good!
 	default:
 		return fmt.Errorf("unknown version scheme: %s", d.Scheme)
+	}
+
+	// Validate RefPaths
+	for _, refPath := range d.RefPaths {
+		if refPath.Path == "" {
+			return fmt.Errorf("dependency %s is invalid: refPath is missing `path`", d.Name)
+		}
+		if refPath.Match == "" {
+			return fmt.Errorf("dependency %s is invalid: refPath is missing `match`", d.Name)
+		}
 	}
 
 	log.Debugf("Deserialised Dependency %s: %#v", d.Name, d)

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -86,6 +86,15 @@ func TestLocalTypo(t *testing.T) {
 	require.Contains(t, err.Error(), "unexpected key: mathc")
 }
 
+func TestLocalIncompleteRefPath(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	err = client.LocalCheck("../testdata/local-malformed-refpath.yaml", "../testdata")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dependency terraform is invalid: refPath is missing `match`")
+}
+
 func TestFileDoesntExist(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -77,6 +77,15 @@ func TestLocalInvalid(t *testing.T) {
 	require.Contains(t, err.Error(), "compiling regex")
 }
 
+func TestLocalTypo(t *testing.T) {
+	client, err := NewLocalClient()
+	require.NoError(t, err)
+
+	err = client.LocalCheck("../testdata/local-typo.yaml", "../testdata")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected key: mathc")
+}
+
 func TestFileDoesntExist(t *testing.T) {
 	client, err := NewLocalClient()
 	require.NoError(t, err)

--- a/testdata/local-malformed-refpath.yaml
+++ b/testdata/local-malformed-refpath.yaml
@@ -1,0 +1,6 @@
+dependencies:
+- name: terraform
+  version: 0.10.0
+  refPaths:
+  - path: Dockerfile
+    # forgot to add a match whoops

--- a/testdata/local-typo.yaml
+++ b/testdata/local-typo.yaml
@@ -1,0 +1,6 @@
+dependencies:
+- name: terraform
+  version: 0.10.0
+  refPaths:
+  - path: Dockerfile
+    mathc: misspelt-match-there-whoops


### PR DESCRIPTION
#### What this PR does / why we need it:

We currently silently ignore broken configuration, which is dangerous. Let's bubble up errors with configuration, especially:
- unexpected fields, indicating typos or other errors
- missing mandatory fields

#### Which issue(s) this PR fixes:

Fixes #1223 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix silent issues with misspelt keys
```