### PR TITLE
Updates on ci and upgrade go to 1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,17 +3,28 @@ name: Lint
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: false
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1
+          version: v2.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,6 +30,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: false
 
       - name: Install ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,18 +6,26 @@ on:
       - 'main'
   pull_request:
 
+permissions: {}
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Check out code onto GOPATH
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: false
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
@@ -50,6 +58,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install tejolote
         uses: kubernetes-sigs/release-actions/setup-tejolote@a30d93cf2aa029e1e4c8a6c79f766aebf429fddb # v0.3.1

--- a/buoy/go.mod
+++ b/buoy/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/zeitgeist/buoy
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/zeitgeist
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.2


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:

- Updates on ci and upgrade go to 1.25


need: https://github.com/kubernetes/test-infra/pull/35408

/assign @saschagrunert @Verolop @puerco 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:



None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires
additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updates on ci and upgrade go to 1.25
```
