### PR TITLE
Add --strict-ref-matches flag to control version match behaviour

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -74,6 +74,13 @@ func New(opts Options, zeitVersionType ZeitgeistType) *cobra.Command {
 		"the logging verbosity, either "+log.LevelNames(),
 	)
 
+	cmd.PersistentFlags().BoolVar(
+		&rootOpts.strictRefMatches,
+		"strict-ref-matches",
+		true,
+		"if true (default), ALL lines matching a refPath's match regexp must contain the expected version; if false, AT LEAST ONE matching line must contain the version",
+	)
+
 	AddCommands(cmd)
 	cmd.AddCommand(version.WithFont("shadow"))
 	return cmd

--- a/commands/export.go
+++ b/commands/export.go
@@ -108,7 +108,7 @@ func addExport(topLevel *cobra.Command) {
 // runValidate is the function invoked by 'addValidate', responsible for
 // validating dependencies in a specified configuration file.
 func runExport(opts *exportOptions) error {
-	client, err := dependency.NewRemoteClient()
+	client, err := dependency.NewRemoteClient(opts.rootOpts.strictRefMatches)
 	if err != nil {
 		return err
 	}

--- a/commands/options.go
+++ b/commands/options.go
@@ -25,7 +25,8 @@ import (
 
 type options struct {
 	// configuration options
-	localOnly bool
+	localOnly        bool
+	strictRefMatches bool
 
 	// path options
 	basePath   string

--- a/commands/set_version.go
+++ b/commands/set_version.go
@@ -51,7 +51,7 @@ func runSetVersion(opts *options, args []string) error {
 		return errors.New("expected exactly two arguments: <dependency> <version>")
 	}
 
-	client, err := dependency.NewLocalClient()
+	client, err := dependency.NewLocalClient(opts.strictRefMatches)
 	if err != nil {
 		return err
 	}

--- a/commands/upgrade.go
+++ b/commands/upgrade.go
@@ -46,7 +46,7 @@ func addUpgrade(topLevel *cobra.Command) {
 // runUpgrade is the function invoked by 'addUpgrade', responsible for
 // upgrading dependencies.
 func runUpgrade(opts *options) error {
-	client, err := dependency.NewRemoteClient()
+	client, err := dependency.NewRemoteClient(opts.strictRefMatches)
 	if err != nil {
 		return err
 	}

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -51,9 +51,9 @@ func runValidate(opts *options) error {
 		err    error
 	)
 	if opts.localOnly {
-		client, err = dependency.NewLocalClient()
+		client, err = dependency.NewLocalClient(opts.strictRefMatches)
 	} else {
-		client, err = dependency.NewRemoteClient()
+		client, err = dependency.NewRemoteClient(opts.strictRefMatches)
 	}
 	if err != nil {
 		return fmt.Errorf("constructing client: %w", err)

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -186,11 +186,16 @@ func ToFile(dependencyFilePath string, dependencies *Dependencies) error {
 	return nil
 }
 
-type LocalClient struct{}
+type LocalClient struct {
+	// StrictRefMatches controls whether ALL lines matching a refPath's match regexp must contain
+	// the version (true), or whether AT LEAST ONE matching line must contain the version (false).
+	// Defaults to true. Set to false to preserve the behaviour from before bd27f1b.
+	StrictRefMatches bool
+}
 
-// NewClient returns all clients that can be used to the validation.
-func NewLocalClient() (Client, error) {
-	return &LocalClient{}, nil
+// NewLocalClient returns a client for local dependency checks.
+func NewLocalClient(strictRefMatches bool) (Client, error) {
+	return &LocalClient{StrictRefMatches: strictRefMatches}, nil
 }
 
 // LocalCheck checks whether dependencies are in-sync locally
@@ -224,7 +229,10 @@ func (c *LocalClient) LocalCheck(dependencyFilePath, basePath string) error {
 			}
 			scanner := bufio.NewScanner(file)
 
+			strict := c.StrictRefMatches
+
 			var found bool
+			var versionFound bool
 			var wrongVersion bool
 
 			var lineNumber int
@@ -232,40 +240,47 @@ func (c *LocalClient) LocalCheck(dependencyFilePath, basePath string) error {
 				lineNumber++
 
 				line := scanner.Text()
-				if matcher.MatchString(line) {
-					found = true
+				if !matcher.MatchString(line) {
+					continue
+				}
+
+				found = true
+				log.Debugf(
+					"Line %d matches expected regexp %q",
+					lineNumber,
+					match,
+				)
+
+				if strings.Contains(line, dep.Version) {
+					versionFound = true
 					log.Debugf(
-						"Line %d matches expected regexp %q",
+						"Line %d matches expected regexp %q and version %q: %s",
 						lineNumber,
 						match,
+						dep.Version,
+						line,
 					)
-
-					if strings.Contains(line, dep.Version) {
-						log.Debugf(
-							"Line %d matches expected regexp %q and version %q: %s",
-							lineNumber,
-							match,
-							dep.Version,
-							line,
-						)
-					} else {
-						log.Warnf(
-							"Line %d matches expected regexp %q but version %q is not present: %s",
-							lineNumber,
-							match,
-							dep.Version,
-							line,
-						)
-						wrongVersion = true
-					}
+				} else {
+					log.Warnf(
+						"Line %d matches expected regexp %q but version %q is not present: %s",
+						lineNumber,
+						match,
+						dep.Version,
+						line,
+					)
+					wrongVersion = strict
 				}
 			}
 
-			if !found {
+			switch {
+			case !found:
 				log.Debugf("No match found in file %s", filePath)
 				nonMatchingPaths = append(nonMatchingPaths, refPath.Path)
-			} else if wrongVersion {
+			case wrongVersion:
 				log.Debugf("Wrong version found in file %s", filePath)
+				nonMatchingPaths = append(nonMatchingPaths, refPath.Path)
+			case !strict && !versionFound:
+				log.Debugf("No line with correct version found in file %s", filePath)
 				nonMatchingPaths = append(nonMatchingPaths, refPath.Path)
 			}
 		}
@@ -348,7 +363,7 @@ func (c *LocalClient) CheckUpstreamVersions(deps []*Dependency) ([]VersionUpdate
 	return nil, UnsupportedError{"CheckUpstreamVersions is not supported by the local client"}
 }
 
-var NewRemoteClient = func() (Client, error) {
+var NewRemoteClient = func(_ bool) (Client, error) {
 	return nil, UnsupportedError{"remote upstream functionality is not supported by this command; use sigs.k8s.io/zeitgeist/remote/zeitgeist"}
 }
 

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestUnsupported(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 	_, err = client.RemoteCheck("")
 	require.ErrorAs(t, err, &UnsupportedError{})
@@ -37,7 +37,7 @@ func TestUnsupported(t *testing.T) {
 }
 
 func TestLocalSuccess(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local.yaml", "../testdata")
@@ -45,7 +45,7 @@ func TestLocalSuccess(t *testing.T) {
 }
 
 func TestLocalMultipleMatches(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-multi-in-sync.yaml", "../testdata")
@@ -53,7 +53,7 @@ func TestLocalMultipleMatches(t *testing.T) {
 }
 
 func TestLocalMultipleMatchesOutOfSync(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-multi-out-of-sync.yaml", "../testdata")
@@ -61,13 +61,24 @@ func TestLocalMultipleMatchesOutOfSync(t *testing.T) {
 	require.Contains(t, err.Error(), "not in sync")
 }
 
+// TestLocalMultipleMatchesOutOfSyncNonStrict verifies that with strict=false,
+// a file where at least one matching line contains the correct version passes,
+// even if other matching lines do not contain the version.
+func TestLocalMultipleMatchesOutOfSyncNonStrict(t *testing.T) {
+	client, err := NewLocalClient(false)
+	require.NoError(t, err)
+
+	err = client.LocalCheck("../testdata/local-multi-out-of-sync.yaml", "../testdata")
+	require.NoError(t, err)
+}
+
 func TestRemoteUnsupported(t *testing.T) {
-	_, err := NewRemoteClient()
+	_, err := NewRemoteClient(true)
 	require.ErrorAs(t, err, &UnsupportedError{})
 }
 
 func TestBrokenFile(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/does-not-exist", "../testdata")
@@ -78,7 +89,7 @@ func TestBrokenFile(t *testing.T) {
 }
 
 func TestLocalOutOfSync(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-out-of-sync.yaml", "../testdata")
@@ -87,7 +98,7 @@ func TestLocalOutOfSync(t *testing.T) {
 }
 
 func TestLocalInvalid(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-invalid.yaml", "../testdata")
@@ -96,7 +107,7 @@ func TestLocalInvalid(t *testing.T) {
 }
 
 func TestLocalTypo(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-typo.yaml", "../testdata")
@@ -105,7 +116,7 @@ func TestLocalTypo(t *testing.T) {
 }
 
 func TestLocalIncompleteRefPath(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-malformed-refpath.yaml", "../testdata")
@@ -114,7 +125,7 @@ func TestLocalIncompleteRefPath(t *testing.T) {
 }
 
 func TestFileDoesntExist(t *testing.T) {
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 
 	err = client.LocalCheck("../testdata/local-no-file.yaml", "../testdata")
@@ -176,7 +187,7 @@ dependencies:
 `), 0o644)
 	require.NoError(t, err)
 
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 	err = client.SetVersion(filepath.Join(dir, "dependencies.yaml"), dir, "app1", "2.1.0")
 	if err != nil {
@@ -215,7 +226,7 @@ dependencies:
 `), 0o644)
 	require.NoError(t, err)
 
-	client, err := NewLocalClient()
+	client, err := NewLocalClient(true)
 	require.NoError(t, err)
 	err = client.SetVersion(filepath.Join(dir, "dependencies.yaml"), dir, "app1", "2.1.0")
 	if err != nil {

--- a/remote/dependency/dependency.go
+++ b/remote/dependency/dependency.go
@@ -46,8 +46,8 @@ type EC2DescribeImagesAPI interface {
 	DescribeImages(ctx context.Context, params *ec2.DescribeImagesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeImagesOutput, error)
 }
 
-func NewRemoteClient() (deppkg.Client, error) {
-	localClient, err := deppkg.NewLocalClient()
+func NewRemoteClient(strictRefMatches bool) (deppkg.Client, error) {
+	localClient, err := deppkg.NewLocalClient(strictRefMatches)
 	if err != nil {
 		return nil, err
 	}

--- a/remote/dependency/dependency_test.go
+++ b/remote/dependency/dependency_test.go
@@ -59,7 +59,7 @@ func TestRemoteSuccess(t *testing.T) {
 }
 
 func TestDummyRemote(t *testing.T) {
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 
 	_, err = client.RemoteCheck("../testdata/remote-dummy.yaml")
@@ -67,7 +67,7 @@ func TestDummyRemote(t *testing.T) {
 }
 
 func TestDummyRemoteExportWithoutUpdate(t *testing.T) {
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 
 	updates, err := client.RemoteExport("../testdata/remote-dummy.yaml")
@@ -76,7 +76,7 @@ func TestDummyRemoteExportWithoutUpdate(t *testing.T) {
 }
 
 func TestDummyRemoteExportWithUpdate(t *testing.T) {
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 
 	updates, err := client.RemoteExport("../testdata/remote-dummy-with-update.yaml")
@@ -88,7 +88,7 @@ func TestDummyRemoteExportWithUpdate(t *testing.T) {
 }
 
 func TestRemoteConstraint(t *testing.T) {
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 
 	_, err = client.RemoteCheck("../testdata/remote-constraint.yaml")
@@ -96,7 +96,7 @@ func TestRemoteConstraint(t *testing.T) {
 }
 
 func TestUnknownFlavour(t *testing.T) {
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 
 	_, err = client.RemoteCheck("../testdata/unknown-upstream.yaml")
@@ -134,7 +134,7 @@ func TestCheckUpstreamVersions(t *testing.T) {
 		},
 	}
 
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 	updateInfos, err := client.CheckUpstreamVersions(deps)
 	require.NoError(t, err)
@@ -189,7 +189,7 @@ func TestCheckUpstreamVersionsTolerant(t *testing.T) {
 		},
 	}
 
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 	updateInfos, err := client.CheckUpstreamVersions(deps)
 	require.NoError(t, err)
@@ -243,7 +243,7 @@ dependencies:
 `), 0o644)
 	require.NoError(t, err)
 
-	client, err := NewRemoteClient()
+	client, err := NewRemoteClient(true)
 	require.NoError(t, err)
 	ret, err := client.Upgrade(filepath.Join(dir, "dependencies.yaml"), dir)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind regression

#### What this PR does / why we need it:

bd27f1b changed LocalCheck so that ALL lines matching a refPath's match
regexp must contain the expected version. This broke configs where a
variable name (e.g. HELM_VERSION) appears on both an assignment line
(which contains the version) and usage lines (which don't).

It was normal and possible to write code like

### update.sh
```bash
HELM_VERSION=4.2.0

helm ... --option $HELM_VERSION
```

now it complains that the last line does not match HELM_VERSION. There are workarounds like `^HELM_VERSION=` but it doesn't feel as natural as it was.

#### Which issue(s) this PR fixes:

--strict-ref-matches=false preserves the original behaviour from before bd27f1b.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add a --strict-ref-matches boolean flag (default: true) to preserve the
current strict behaviour by default, while allowing users to opt out with
--strict-ref-matches=false. In non-strict mode, AT LEAST ONE line
matching the regexp must contain the version
```
