### PR TITLE
Check the go-import meta tag has all three fields

### DIFF
--- a/buoy/pkg/golang/goimport.go
+++ b/buoy/pkg/golang/goimport.go
@@ -94,6 +94,9 @@ func GetMetaImport(url string) (*MetaImport, error) {
 	}
 
 	f := strings.Fields(content)
+	if len(f) < 3 {
+		return nil, fmt.Errorf("go-import meta tag has %d fields, want a prefix, a vcs and a repo root: %q", len(f), content)
+	}
 
 	return &MetaImport{
 		Prefix:   f[0],

--- a/buoy/pkg/golang/goimport_test.go
+++ b/buoy/pkg/golang/goimport_test.go
@@ -175,3 +175,25 @@ func TestGetMetaImport_MissingGoImport(t *testing.T) {
 	_, err := GetMetaImport(ts.URL)
 	require.Error(t, err)
 }
+
+func TestGetMetaImport_ShortGoImport(t *testing.T) {
+	tests := map[string]string{
+		"prefix only":     "tableflip.dev/buoy",
+		"no repo root":    "tableflip.dev/buoy git",
+		"empty content":   "",
+		"only whitespace": "   ",
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// nolint: errcheck
+				w.Write([]byte(`<html><head><meta name="go-import" content="` + content + `"></head></html>`))
+			}))
+			defer ts.Close()
+
+			_, err := GetMetaImport(ts.URL)
+			require.Error(t, err)
+		})
+	}
+}

--- a/buoy/pkg/golang/goimport_test.go
+++ b/buoy/pkg/golang/goimport_test.go
@@ -193,7 +193,7 @@ func TestGetMetaImport_ShortGoImport(t *testing.T) {
 			defer ts.Close()
 
 			_, err := GetMetaImport(ts.URL)
-			require.Error(t, err)
+			require.ErrorContains(t, err, "fields")
 		})
 	}
 }


### PR DESCRIPTION
`GetMetaImport` reads three fields out of the `go-import` meta tag without checking how many it got:

```go
f := strings.Fields(content)

return &MetaImport{
    Prefix:   f[0],
    VCS:      f[1],
    RepoRoot: f[2],
}, nil
```

`content` is whatever the module host puts in the tag at `https://<module>?go-get=1`. A tag with fewer than three fields, or an empty one, ends the process:

```
panic: runtime error: index out of range [0] with length 0
	sigs.k8s.io/zeitgeist/buoy/pkg/golang.GetMetaImport(...)
	buoy/pkg/golang/goimport.go:96
```

`ModuleToRepo` calls it for modules read out of a `go.mod`, so the input is remote and the caller has no way to sanitize it first. A vanity-import host that is misconfigured, half-deployed, or serving an error page with a stub tag takes buoy down rather than producing an error for that one dependency. `cmd/go` handles the same tag defensively, skipping any go-import whose content does not split into three fields.

This returns an error naming the field count and the content. The existing `metaContent` failure already returns an error the same way, so nothing above needs to change.

The new table in `goimport_test.go` follows `TestGetMetaImport_MissingGoImport`: an httptest server serves a tag with one field, two fields, empty content and whitespace-only content, and each is expected to error. Without the change the whitespace-only and empty cases panic with the message above and take the test binary with them. `go build ./...`, `go vet ./pkg/golang/...` and `go test ./pkg/golang/...` are clean in the `buoy` module.
